### PR TITLE
add GHA workflow to create release on tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Create Release
+
+on:
+    push:
+        tags:
+            - "*"
+
+jobs:
+    build:
+        if: github.event.base_ref == 'refs/heads/main'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Release
+              uses: softprops/action-gh-release@v1
+              with:
+                  generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Create Release
 on:
     push:
         tags:
-            - "*"
+            - v*
 
 jobs:
     build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,18 @@
-name: Create Release
+name: Create Release from the version tag
 
 on:
     push:
         tags:
-            - v*
+            - "v*.*.*"
 
 jobs:
     build:
-        if: github.event.base_ref == 'refs/heads/main'
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout
+            - name: Checkout repository.
               uses: actions/checkout@v3
 
-            - name: Release
+            - name: Create Release.
               uses: softprops/action-gh-release@v1
               with:
                   generate_release_notes: true


### PR DESCRIPTION
This would make releasing as easy as

```shell
git tag vx.x.x && git push --tags
```