### PR TITLE
Fix a small typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ client = Client()
 # Client('https://my.awesome.server/xrpc')
 ```
 
-Fro async:
+For async:
 ```python
 from atproto import AsyncClient
 


### PR DESCRIPTION
Fixes a small typo... "for" instead of "fro".