### PR TITLE
Ignore extra fields instead of forbidding

### DIFF
--- a/atproto/xrpc_client/models/base.py
+++ b/atproto/xrpc_client/models/base.py
@@ -13,7 +13,7 @@ class ModelBase(BaseModel, AtProtocolBase):
     Provides square brackets [] notation to get attributes like in a dictionary.
     """
 
-    model_config = ConfigDict(extra='allow', populate_by_name=True, strict=True)
+    model_config = ConfigDict(extra='ignore', populate_by_name=True, strict=True)
 
     def __getitem__(self, item: str):
         if hasattr(self, item):

--- a/atproto/xrpc_client/models/base.py
+++ b/atproto/xrpc_client/models/base.py
@@ -13,7 +13,7 @@ class ModelBase(BaseModel, AtProtocolBase):
     Provides square brackets [] notation to get attributes like in a dictionary.
     """
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True, strict=True)
+    model_config = ConfigDict(extra='allow', populate_by_name=True, strict=True)
 
     def __getitem__(self, item: str):
         if hasattr(self, item):

--- a/tests/models/tests/test_custom_like_record.py
+++ b/tests/models/tests/test_custom_like_record.py
@@ -1,6 +1,5 @@
 from atproto.xrpc_client import models
 from atproto.xrpc_client.models import get_model_as_dict, get_or_create
-from atproto.xrpc_client.models.dot_dict import DotDict
 from tests.models.tests.utils import load_data_from_file
 
 TEST_DATA = load_data_from_file('custom_like_record')
@@ -10,12 +9,15 @@ def test_custom_like_record_deserialization():
     model = get_or_create(TEST_DATA, models.ComAtprotoRepoGetRecord.Response)
 
     assert isinstance(model, models.ComAtprotoRepoGetRecord.Response)
-    assert isinstance(model.value, DotDict)
+    assert isinstance(model.value, models.AppBskyFeedLike.Main)
 
-    assert model.value['$type'] == models.ids.AppBskyFeedLike
-    # record_type is the custom field out of lexicon
-    assert model.value.record_type == 'app.bsky.feed.like'
-    assert model.value['record_type'] == 'app.bsky.feed.like'
+    # assert model.value['$type'] == models.ids.AppBskyFeedLike
+    assert model.value.py_type == models.ids.AppBskyFeedLike
+    assert model.value['py_type'] == models.ids.AppBskyFeedLike
+
+    # we should ignore extra fields
+    assert 'createdAt' in get_model_as_dict(model)['value']
+    assert 'record_type' not in get_model_as_dict(model)['value']
 
 
 def test_custom_like_record_serialization():
@@ -27,10 +29,10 @@ def test_custom_like_record_serialization():
     assert isinstance(get_model_as_dict(model.value), dict)
     assert model_dict == get_model_as_dict(restored_model)
 
-    assert restored_model.value['$type'] == models.ids.AppBskyFeedLike
-    # record_type is the custom field out of lexicon
-    assert restored_model.value.record_type == 'app.bsky.feed.like'
-    assert restored_model.value['record_type'] == 'app.bsky.feed.like'
+    assert restored_model.value.py_type == models.ids.AppBskyFeedLike
 
     assert model_dict['value']['$type'] == models.ids.AppBskyFeedLike
-    assert model_dict['value']['record_type'] == 'app.bsky.feed.like'
+
+    # we should ignore extra fields
+    assert 'createdAt' in get_model_as_dict(model)['value']
+    assert 'record_type' not in get_model_as_dict(model)['value']

--- a/tests/models/tests/test_custom_post_record.py
+++ b/tests/models/tests/test_custom_post_record.py
@@ -1,6 +1,5 @@
 from atproto.xrpc_client import models
 from atproto.xrpc_client.models import get_model_as_dict, get_or_create
-from atproto.xrpc_client.models.dot_dict import DotDict
 from tests.models.tests.utils import load_data_from_file
 
 TEST_DATA = load_data_from_file('custom_post_record')
@@ -10,12 +9,12 @@ def test_custom_post_record_deserialization():
     model = get_or_create(TEST_DATA, models.ComAtprotoRepoGetRecord.Response)
 
     assert isinstance(model, models.ComAtprotoRepoGetRecord.Response)
-    assert isinstance(model.value, DotDict)
+    assert isinstance(model.value, models.AppBskyFeedPost.Main)
 
-    assert model.value['$type'] == models.ids.AppBskyFeedPost
-    # lol is the custom field out of lexicon
-    assert model.value.lol == 'kek'
-    assert model.value['lol'] == 'kek'
+    assert model.value.py_type == models.ids.AppBskyFeedPost
+    # lol is the custom field, this should be ignored
+    assert 'createdAt' in get_model_as_dict(model)['value']
+    assert 'lol' not in get_model_as_dict(model)['value']
 
 
 def test_custom_post_record_serialization():
@@ -27,10 +26,8 @@ def test_custom_post_record_serialization():
     assert isinstance(get_model_as_dict(model.value), dict)
     assert model_dict == get_model_as_dict(restored_model)
 
-    assert restored_model.value['$type'] == models.ids.AppBskyFeedPost
-    # lol is the custom field out of lexicon
-    assert restored_model.value.lol == 'kek'
-    assert restored_model.value['lol'] == 'kek'
+    assert restored_model.value.py_type == models.ids.AppBskyFeedPost
 
-    assert model_dict['value']['$type'] == models.ids.AppBskyFeedPost
-    assert model_dict['value']['lol'] == 'kek'
+    # lol is the custom field, this should be ignored
+    assert 'createdAt' in get_model_as_dict(model)['value']
+    assert 'lol' not in get_model_as_dict(model)['value']

--- a/tests/models/tests/test_is_record_type.py
+++ b/tests/models/tests/test_is_record_type.py
@@ -1,6 +1,5 @@
 from atproto.xrpc_client import models
 from atproto.xrpc_client.models import get_or_create, is_record_type
-from atproto.xrpc_client.models.dot_dict import DotDict
 from tests.models.tests.utils import load_data_from_file
 
 TEST_DATA_LEXICON_CORRECT = load_data_from_file('post_record')
@@ -17,7 +16,7 @@ def test_is_record_type():
     assert is_record_type(lexicon_correct_post_record.value, models.AppBskyFeedPost) is True
     assert is_record_type(lexicon_correct_post_record.value, models.AppBskyFeedGenerator) is False
 
-    assert isinstance(extended_post_record.value, DotDict)
+    assert isinstance(extended_post_record.value, models.AppBskyFeedPost.Main)
     assert is_record_type(extended_post_record.value, models.ids.AppBskyFeedPost) is True
     assert is_record_type(extended_post_record.value, models.ids.AppBskyFeedGenerator) is False
     assert is_record_type(extended_post_record.value, models.AppBskyFeedPost) is True


### PR DESCRIPTION
The spec for lexicon, indicates that extra fields should be ignored. 

> Unexpected fields in data which otherwise conforms to the Lexicon should be ignored. When doing schema validation, they should be treated at worst as warnings. This is necessary to allow evolution of the schema by the controlling authority, and to be robust in the case of out-of-date Lexicons.

[ATProto Lexicon#authority-and-control](https://atproto.com/specs/lexicon#authority-and-control)

Although this may change in future

> The validation rules for unexpected additional fields may change. For example, a mechanism for Lexicons to indicate that the schema is "closed" and unexpected fields are not allowed, or a convention around field name prefixes (x-) to indicate unofficial extension.

[ATProto Lexicon#possible-future-changes](https://atproto.com/specs/lexicon#possible-future-changes)

At the moment, extra fields are causing an error, due to **Pydantic** being configured to 'forbid' these.
Changing the base mode `ConfigDict` with `extra='ignore'` and keeping `strict=True`, will keep validation, but allow extra fields.
