### PR TITLE
Cleanup docs of models by disabling aliases, schemes, validators, list of fields

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,9 +126,10 @@ ogp_enable_meta_description = True
 # Pydantic models
 autodoc_pydantic_model_undoc_members = True
 autodoc_pydantic_model_show_json = True
-autodoc_pydantic_settings_show_json = False
 autodoc_pydantic_model_show_config_summary = False
-autodoc_pydantic_settings_show_validator_summary = False
+autodoc_pydantic_model_show_validator_summary = False
+autodoc_pydantic_field_list_validators = False
+autodoc_pydantic_settings_show_json = False
 
 
 autosectionlabel_prefix_document = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -128,6 +128,7 @@ autodoc_pydantic_model_undoc_members = True
 autodoc_pydantic_model_show_json = True
 autodoc_pydantic_settings_show_json = False
 autodoc_pydantic_model_show_config_summary = False
+autodoc_pydantic_settings_show_validator_summary = False
 
 
 autosectionlabel_prefix_document = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,10 +125,13 @@ ogp_enable_meta_description = True
 
 # Pydantic models
 autodoc_pydantic_model_undoc_members = True
-autodoc_pydantic_model_show_json = True
+autodoc_pydantic_model_show_json = False
 autodoc_pydantic_model_show_config_summary = False
+autodoc_pydantic_model_show_field_summary = False
 autodoc_pydantic_model_show_validator_summary = False
+autodoc_pydantic_model_signature_prefix = 'class'
 autodoc_pydantic_field_list_validators = False
+autodoc_pydantic_field_show_alias = False
 autodoc_pydantic_settings_show_json = False
 
 


### PR DESCRIPTION
for now, we are using only 1 global validator. there is no sense in displaying it in docs for each model and field; aliases are useless for devs; JSON schema is not needed at all; 