### PR TITLE
Add on session change callback

### DIFF
--- a/docs/source/atproto/atproto_client.client.rst
+++ b/docs/source/atproto/atproto_client.client.rst
@@ -25,3 +25,4 @@ Submodules
    atproto_client.client.base
    atproto_client.client.client
    atproto_client.client.raw
+   atproto_client.client.session

--- a/docs/source/atproto_client/auth.md
+++ b/docs/source/atproto_client/auth.md
@@ -1,0 +1,204 @@
+## Auth
+
+The AT Protocol has two kinds of authentication: client-server and service-to-service.
+This page describes the basics of client-server authentication.
+
+### Login
+
+Login takes a username (handle) and password and returns a session.
+Sessions are presented with access and refresh tokens.
+
+Depending on account status and password, the access token permissions are varied.
+For example, access tokens created with app-password have limited permissions to create new app-passwords, change email, etc.
+
+The session is created via the [login](#atproto_client.client.client.Client.login) method. 
+Under the hood, the SDK uses [create_session](#atproto_client.namespaces.sync_ns.ServerNamespace.create_session) method.
+
+```python
+from atproto_client import Client
+
+client = Client()
+client.login('username', 'password')
+```
+
+The access and refresh tokens are stored in the client object and are used for subsequent requests.
+SDK will automatically refresh the access token when it expires. 
+So, you don't need to worry about it at all.
+
+It works amazingly well until you don't recreate the client instance many times.
+If it's possible, try to keep the client instance alive as long as possible.
+For example, instead of starting the script by `cron` every 5 minutes, keep it running and use the `sleep` function.
+
+This is incredibly important because API is rate-limited, and you can reach the limit. 
+Which can lead to a temporary outage of your project.
+
+The current rate limits are provided in the [API documentation](https://www.docs.bsky.app/docs/advanced-guides/rate-limits).
+
+- `createSession`:
+  - Rate limited by handle
+  - 30 requests per 5 minutes (30/5 min)
+  - 300 requests per day (300/day)
+
+If you can't keep the client instance alive, for example, a stateless server, you should reuse the created session.
+See below how to do it.
+
+### Session string
+
+We have two types of tokens: access and refresh.
+The access token is used to authenticate requests to the server.
+The refresh token is used to get a new access token when the old one expires.
+
+The access token is valid for ~2 hours, and the refresh token is valid for ~2 months.
+
+SDK will automatically refresh the access token when it expires using [refresh_session](#atproto_client.namespaces.sync_ns.ServerNamespace.refresh_session) method.
+
+You are always able to export the current session to persistent storage and import it later.
+To export the session, use the [export_session_string](#atproto_client.client.client.Client.export_session_string) method.
+
+Example how to export the session to a file:
+```python
+from atproto_client import Client
+
+
+client = Client()
+client.login('username', 'password')
+
+session_string = client.export_session_string()
+with open('session.txt', 'w') as f:
+    f.write(session_string)
+```
+
+To import the session from persistent storage, use the `session_string` argument of the [login](#atproto_client.client.client.Client.login) method.
+
+```python
+from atproto_client import Client
+
+
+client = Client()
+with open('session.txt') as f:
+    session_string = f.read()
+    
+client.login(session_string=session_string)
+```
+
+:::{warning}
+Because of automatic token refreshing, the session string changes every time the access token is refreshed! 
+The `export_session_string` method can return different session strings depending on the time of the call. 
+This is expected behavior that you should be aware of.
+:::
+
+:::{attention}
+On the token refresh, the old refresh token will be revoked instantly.
+You must use only the fresh pair of tokens (access + refresh).
+It's not possible to reuse the same refresh token multiple times.
+:::
+
+According to the warnings above, you should always export the session string at the end of the script.
+Alternatively, to avoid unhandled errors in your project, or to not deal with the life cycle of your application, 
+you can subscribe to the `on_session_changed` event and export the session string from it.
+
+```python
+from atproto import Client, SessionEvent, Session
+
+
+client = Client()
+
+@client.on_session_change
+def on_session_change(event: SessionEvent, session: Session):
+    print(event, session)
+```
+
+For asynchronous code:
+
+```python
+from atproto import AsyncClient, SessionEvent, Session
+
+
+client = AsyncClient()
+
+@client.on_session_change
+async def on_session_change(event: SessionEvent, session: Session):
+    print(event, session)
+```
+
+
+Possible events are:
+- `SessionEvent.CREATE` - when the session is created
+- `SessionEvent.REFRESH` - when the session is refreshed
+- `SessionEvent.IMPORT` - when the session is imported from a string
+
+CREATE:
+```python
+# this will trigger the on_session_change with SessionEvent.CREATE event
+client.login('username', 'password')
+```
+
+IMPORT:
+```python
+# this will trigger the on_session_change with SessionEvent.IMPORT event
+client.login(session_string='exportedSession')
+```
+
+REFRESH:
+```python
+# whenever SDK will refresh the access token, 
+# the on_session_change will be triggered 
+# with SessionEvent.REFRESH event
+```
+
+You should save the session string to a persistent storage, like a file or database, on the `SessionEvent.CREATE` and `SessionEvent.REFRESH` events.
+
+Not a production-ready code, but you can use it as a starting point:
+
+```python
+from typing import Optional
+
+from atproto_client import Client, Session, SessionEvent
+
+
+def get_session() -> Optional[str]:
+    try:
+        with open('session.txt') as f:
+            return f.read()
+    except FileNotFoundError:
+        return None
+
+
+def save_session(session_string: str) -> None:
+    with open('session.txt', 'w') as f:
+        f.write(session_string)
+
+
+def on_session_change(event: SessionEvent, session: Session) -> None:
+    print('Session changed:', event, repr(session))
+    if event in (SessionEvent.CREATE, SessionEvent.REFRESH):
+        print('Saving changed session')
+        save_session(session.export())
+
+
+def init_client() -> Client:
+    client = Client()
+    client.on_session_change(on_session_change)
+
+    session_string = get_session()
+    if session_string:
+        print('Reusing session')
+        client.login(session_string=session_string)
+    else:
+        print('Creating new session')
+        client.login('username', 'password')
+
+    return client
+
+
+if __name__ == '__main__':
+    client = init_client()
+    # do something with the client
+    print('Client is ready to use!')
+```
+
+:::{tip}
+Don't store the password in the file or database.
+The best scenario is to use a password only at the first login.
+Later, use the session string to authenticate and store it in a persistent storage.
+:::

--- a/docs/source/atproto_client/index.rst
+++ b/docs/source/atproto_client/index.rst
@@ -15,4 +15,5 @@ Submodules
    clients
    namespace
    models
+   auth
    utils/index

--- a/examples/advanced_usage/session_reuse.py
+++ b/examples/advanced_usage/session_reuse.py
@@ -1,0 +1,44 @@
+from typing import Optional
+
+from atproto_client import Client, Session, SessionEvent
+
+
+def get_session() -> Optional[str]:
+    try:
+        with open('session.txt') as f:
+            return f.read()
+    except FileNotFoundError:
+        return None
+
+
+def save_session(session_string: str) -> None:
+    with open('session.txt', 'w') as f:
+        f.write(session_string)
+
+
+def on_session_change(event: SessionEvent, session: Session) -> None:
+    print('Session changed:', event, repr(session))
+    if event in (SessionEvent.CREATE, SessionEvent.REFRESH):
+        print('Saving changed session')
+        save_session(session.export())
+
+
+def init_client() -> Client:
+    client = Client()
+    client.on_session_change(on_session_change)
+
+    session_string = get_session()
+    if session_string:
+        print('Reusing session')
+        client.login(session_string=session_string)
+    else:
+        print('Creating new session')
+        client.login('username', 'password')
+
+    return client
+
+
+if __name__ == '__main__':
+    client = init_client()
+    # do something with the client
+    print('Client is ready to use!')

--- a/packages/atproto/__init__.py
+++ b/packages/atproto/__init__.py
@@ -1,4 +1,4 @@
-from atproto_client import AsyncClient, Client, SessionChangeEvent, SessionString, models
+from atproto_client import AsyncClient, Client, Session, SessionEvent, models
 from atproto_client import utils as client_utils
 from atproto_core.car import CAR
 from atproto_core.cid import CID, CIDType
@@ -34,8 +34,8 @@ __all__ = [
     # client
     'AsyncClient',
     'Client',
-    'SessionChangeEvent',
-    'SessionString',
+    'SessionEvent',
+    'Session',
     'client_utils',
     'models',
     # core

--- a/packages/atproto/__init__.py
+++ b/packages/atproto/__init__.py
@@ -1,4 +1,4 @@
-from atproto_client import AsyncClient, Client, models
+from atproto_client import AsyncClient, Client, SessionChangeEvent, SessionString, models
 from atproto_client import utils as client_utils
 from atproto_core.car import CAR
 from atproto_core.cid import CID, CIDType
@@ -34,6 +34,8 @@ __all__ = [
     # client
     'AsyncClient',
     'Client',
+    'SessionChangeEvent',
+    'SessionString',
     'client_utils',
     'models',
     # core

--- a/packages/atproto_client/__init__.py
+++ b/packages/atproto_client/__init__.py
@@ -1,12 +1,12 @@
 from atproto_client import models
 from atproto_client.client.async_client import AsyncClient
 from atproto_client.client.client import Client
-from atproto_client.client.session import SessionChangeEvent, SessionString
+from atproto_client.client.session import Session, SessionEvent
 
 __all__ = [
     'AsyncClient',
     'Client',
     'models',
-    'SessionChangeEvent',
-    'SessionString',
+    'SessionEvent',
+    'Session',
 ]

--- a/packages/atproto_client/__init__.py
+++ b/packages/atproto_client/__init__.py
@@ -1,9 +1,12 @@
 from atproto_client import models
 from atproto_client.client.async_client import AsyncClient
 from atproto_client.client.client import Client
+from atproto_client.client.session import SessionChangeEvent, SessionString
 
 __all__ = [
     'AsyncClient',
     'Client',
     'models',
+    'SessionChangeEvent',
+    'SessionString',
 ]

--- a/packages/atproto_client/client/async_client.py
+++ b/packages/atproto_client/client/async_client.py
@@ -14,7 +14,7 @@ from atproto_client.client.async_raw import AsyncClientRaw
 from atproto_client.client.methods_mixin import SessionMethodsMixin, TimeMethodsMixin
 from atproto_client.client.methods_mixin.session import AsyncSessionDispatchMixin
 from atproto_client.client.methods_mixin.strong_ref_arg_backward_compatibility import _StrongRefArgBackwardCompatibility
-from atproto_client.client.session import SessionChangeEvent, SessionResponse, SessionString
+from atproto_client.client.session import Session, SessionEvent, SessionResponse
 from atproto_client.models.languages import DEFAULT_LANGUAGE_CODE1
 from atproto_client.utils import TextBuilder
 
@@ -46,7 +46,7 @@ class AsyncClient(
 
         return await super()._invoke(invoke_type, **kwargs)
 
-    async def _set_session(self, event: SessionChangeEvent, session: SessionResponse) -> None:
+    async def _set_session(self, event: SessionEvent, session: SessionResponse) -> None:
         self._set_session_common(session)
         await self._call_on_session_change_callbacks(event, self._session.copy())
 
@@ -54,20 +54,20 @@ class AsyncClient(
         session = await self.com.atproto.server.create_session(
             models.ComAtprotoServerCreateSession.Data(identifier=login, password=password)
         )
-        await self._set_session(SessionChangeEvent.CREATE, session)
+        await self._set_session(SessionEvent.CREATE, session)
         return session
 
     async def _refresh_and_set_session(self) -> 'models.ComAtprotoServerRefreshSession.Response':
         refresh_session = await self.com.atproto.server.refresh_session(
             headers=self._get_auth_headers(self._refresh_jwt), session_refreshing=True
         )
-        await self._set_session(SessionChangeEvent.REFRESH, refresh_session)
+        await self._set_session(SessionEvent.REFRESH, refresh_session)
 
         return refresh_session
 
-    async def _import_session_string(self, session_string: str) -> SessionString:
-        import_session = SessionString.decode(session_string)
-        await self._set_session(SessionChangeEvent.IMPORT, import_session)
+    async def _import_session_string(self, session_string: str) -> Session:
+        import_session = Session.decode(session_string)
+        await self._set_session(SessionEvent.IMPORT, import_session)
 
         return import_session
 

--- a/packages/atproto_client/client/client.py
+++ b/packages/atproto_client/client/client.py
@@ -8,7 +8,7 @@ from atproto_client.client.methods_mixin import SessionMethodsMixin, TimeMethods
 from atproto_client.client.methods_mixin.session import SessionDispatchMixin
 from atproto_client.client.methods_mixin.strong_ref_arg_backward_compatibility import _StrongRefArgBackwardCompatibility
 from atproto_client.client.raw import ClientRaw
-from atproto_client.client.session import SessionChangeEvent, SessionResponse, SessionString
+from atproto_client.client.session import Session, SessionEvent, SessionResponse
 from atproto_client.models.languages import DEFAULT_LANGUAGE_CODE1
 from atproto_client.utils import TextBuilder
 
@@ -40,7 +40,7 @@ class Client(
 
         return super()._invoke(invoke_type, **kwargs)
 
-    def _set_session(self, event: SessionChangeEvent, session: SessionResponse) -> None:
+    def _set_session(self, event: SessionEvent, session: SessionResponse) -> None:
         self._set_session_common(session)
         self._call_on_session_change_callbacks(event, self._session.copy())
 
@@ -48,20 +48,20 @@ class Client(
         session = self.com.atproto.server.create_session(
             models.ComAtprotoServerCreateSession.Data(identifier=login, password=password)
         )
-        self._set_session(SessionChangeEvent.CREATE, session)
+        self._set_session(SessionEvent.CREATE, session)
         return session
 
     def _refresh_and_set_session(self) -> 'models.ComAtprotoServerRefreshSession.Response':
         refresh_session = self.com.atproto.server.refresh_session(
             headers=self._get_auth_headers(self._refresh_jwt), session_refreshing=True
         )
-        self._set_session(SessionChangeEvent.REFRESH, refresh_session)
+        self._set_session(SessionEvent.REFRESH, refresh_session)
 
         return refresh_session
 
-    def _import_session_string(self, session_string: str) -> SessionString:
-        import_session = SessionString.decode(session_string)
-        self._set_session(SessionChangeEvent.IMPORT, import_session)
+    def _import_session_string(self, session_string: str) -> Session:
+        import_session = Session.decode(session_string)
+        self._set_session(SessionEvent.IMPORT, import_session)
 
         return import_session
 

--- a/packages/atproto_client/client/client.py
+++ b/packages/atproto_client/client/client.py
@@ -5,8 +5,10 @@ from atproto_core.uri import AtUri
 
 from atproto_client import models
 from atproto_client.client.methods_mixin import SessionMethodsMixin, TimeMethodsMixin
+from atproto_client.client.methods_mixin.session import SessionDispatchMixin
 from atproto_client.client.methods_mixin.strong_ref_arg_backward_compatibility import _StrongRefArgBackwardCompatibility
 from atproto_client.client.raw import ClientRaw
+from atproto_client.client.session import SessionChangeEvent, SessionResponse, SessionString
 from atproto_client.models.languages import DEFAULT_LANGUAGE_CODE1
 from atproto_client.utils import TextBuilder
 
@@ -15,7 +17,9 @@ if t.TYPE_CHECKING:
     from atproto_client.request import Response
 
 
-class Client(_StrongRefArgBackwardCompatibility, SessionMethodsMixin, TimeMethodsMixin, ClientRaw):
+class Client(
+    _StrongRefArgBackwardCompatibility, SessionDispatchMixin, SessionMethodsMixin, TimeMethodsMixin, ClientRaw
+):
     """High-level client for XRPC of ATProto."""
 
     def __init__(self, base_url: t.Optional[str] = None, *args, **kwargs: t.Any) -> None:
@@ -36,21 +40,30 @@ class Client(_StrongRefArgBackwardCompatibility, SessionMethodsMixin, TimeMethod
 
         return super()._invoke(invoke_type, **kwargs)
 
+    def _set_session(self, event: SessionChangeEvent, session: SessionResponse) -> None:
+        self._set_session_common(session)
+        self._call_on_session_change_callbacks(event, self._session.copy())
+
     def _get_and_set_session(self, login: str, password: str) -> 'models.ComAtprotoServerCreateSession.Response':
         session = self.com.atproto.server.create_session(
             models.ComAtprotoServerCreateSession.Data(identifier=login, password=password)
         )
-        self._set_session(session)
-
+        self._set_session(SessionChangeEvent.CREATE, session)
         return session
 
     def _refresh_and_set_session(self) -> 'models.ComAtprotoServerRefreshSession.Response':
         refresh_session = self.com.atproto.server.refresh_session(
             headers=self._get_auth_headers(self._refresh_jwt), session_refreshing=True
         )
-        self._set_session(refresh_session)
+        self._set_session(SessionChangeEvent.REFRESH, refresh_session)
 
         return refresh_session
+
+    def _import_session_string(self, session_string: str) -> SessionString:
+        import_session = SessionString.decode(session_string)
+        self._set_session(SessionChangeEvent.IMPORT, import_session)
+
+        return import_session
 
     def login(
         self, login: t.Optional[str] = None, password: t.Optional[str] = None, session_string: t.Optional[str] = None

--- a/packages/atproto_client/client/methods_mixin/session.py
+++ b/packages/atproto_client/client/methods_mixin/session.py
@@ -1,45 +1,51 @@
+import asyncio
 import typing as t
-from dataclasses import dataclass
 from datetime import timedelta
 
-import typing_extensions as te
 from atproto_server.auth.jwt import get_jwt_payload
+
+from atproto_client.client.session import (
+    AsyncSessionChangeCallback,
+    SessionChangeCallback,
+    SessionChangeEvent,
+    SessionResponse,
+    SessionString,
+)
 
 if t.TYPE_CHECKING:
     from atproto_server.auth.jwt import JwtPayload
 
-    from atproto_client import models
+
+class SessionDispatchMixin:
+    def __init__(self, *args, **kwargs: t.Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        self._on_session_change_callbacks: t.List[SessionChangeCallback] = []
+        self._on_session_change_async_callbacks: t.List[AsyncSessionChangeCallback] = []
+
+    def on_session_change(self, callback: SessionChangeCallback) -> None:
+        self._on_session_change_callbacks.append(callback)
+
+    def _call_on_session_change_callbacks(self, event: SessionChangeEvent, session: SessionString) -> None:
+        for on_session_change_callback in self._on_session_change_callbacks:
+            on_session_change_callback(event, session)
 
 
-@dataclass
-class SessionString:
-    access_jwt: str
-    refresh_jwt: str
-    did: str
-    handle: str
+class AsyncSessionDispatchMixin:
+    def __init__(self, *args, **kwargs: t.Any) -> None:
+        super().__init__(*args, **kwargs)
 
-    _SESSION_STRING_SEPARATOR: te.Final[te.Literal[':::']] = ':::'
+        self._on_session_change_async_callbacks: t.List[AsyncSessionChangeCallback] = []
 
-    def encode(self) -> str:
-        payload = [
-            self.handle,
-            self.did,
-            self.access_jwt,
-            self.refresh_jwt,
-        ]
-        return self._SESSION_STRING_SEPARATOR.join(payload)
+    def on_session_change(self, callback: AsyncSessionChangeCallback) -> None:
+        self._on_session_change_async_callbacks.append(callback)
 
-    @classmethod
-    def decode(cls, string: str) -> 'SessionString':
-        handle, did, access_jwt, refresh_jwt = string.split(cls._SESSION_STRING_SEPARATOR)
-        return cls(access_jwt, refresh_jwt, did, handle)
+    async def _call_on_session_change_callbacks(self, event: SessionChangeEvent, session: SessionString) -> None:
+        coroutines = []
+        for on_session_change_async_callback in self._on_session_change_async_callbacks:
+            coroutines.append(on_session_change_async_callback(event, session))
 
-
-SessionResponse: te.TypeAlias = t.Union[
-    'models.ComAtprotoServerCreateSession.Response',
-    'models.ComAtprotoServerRefreshSession.Response',
-    'SessionString',
-]
+        await asyncio.gather(*coroutines)
 
 
 class SessionMethodsMixin:
@@ -56,11 +62,11 @@ class SessionMethodsMixin:
 
     def _should_refresh_session(self) -> bool:
         expired_at = self.get_time_from_timestamp(self._access_jwt_payload.exp)
-        expired_at = expired_at - timedelta(minutes=15)  # let's update the token a bit later than required
+        expired_at = expired_at - timedelta(minutes=15)  # let's update the token a bit earlier than required
 
         return self.get_current_time() > expired_at
 
-    def _set_session(self, session: SessionResponse) -> None:
+    def _set_session_common(self, session: SessionResponse) -> None:
         self._access_jwt = session.access_jwt
         self._access_jwt_payload = get_jwt_payload(session.access_jwt)
 
@@ -82,11 +88,6 @@ class SessionMethodsMixin:
 
     def _set_auth_headers(self, token: str) -> None:
         self.request.set_additional_headers(self._get_auth_headers(token))
-
-    def _import_session_string(self, string: str) -> SessionString:
-        session = SessionString.decode(string)
-        self._set_session(session)
-        return session
 
     def export_session_string(self) -> str:
         """Export session string.

--- a/packages/atproto_client/client/session.py
+++ b/packages/atproto_client/client/session.py
@@ -8,7 +8,7 @@ if t.TYPE_CHECKING:
     from atproto_client import models
 
 
-class SessionChangeEvent(Enum):
+class SessionEvent(Enum):
     IMPORT = 'import'
     CREATE = 'creat'
     REFRESH = 'refresh'
@@ -18,11 +18,17 @@ _SESSION_STRING_SEPARATOR: te.Final[te.Literal[':::']] = ':::'
 
 
 @dataclass
-class SessionString:
+class Session:
     handle: str
     did: str
     access_jwt: str
     refresh_jwt: str
+
+    def __repr__(self) -> str:
+        return f'<Session handle={self.handle} did={self.did}>'
+
+    def __str__(self) -> str:
+        return self.encode()
 
     def encode(self) -> str:
         payload = [
@@ -34,19 +40,36 @@ class SessionString:
         return _SESSION_STRING_SEPARATOR.join(payload)
 
     @classmethod
-    def decode(cls, session_string: str) -> 'SessionString':
+    def decode(cls, session_string: str) -> 'Session':
         handle, did, access_jwt, refresh_jwt = session_string.split(_SESSION_STRING_SEPARATOR)
         return cls(handle, did, access_jwt, refresh_jwt)
 
-    def copy(self) -> 'SessionString':
-        return SessionString(self.handle, self.did, self.access_jwt, self.refresh_jwt)
+    def copy(self) -> 'Session':
+        return Session(self.handle, self.did, self.access_jwt, self.refresh_jwt)
+
+    #: Alias for :attr:`encode`
+    export = encode
 
 
 SessionResponse: te.TypeAlias = t.Union[
     'models.ComAtprotoServerCreateSession.Response',
     'models.ComAtprotoServerRefreshSession.Response',
-    'SessionString',
+    'Session',
 ]
 
-SessionChangeCallback = t.Callable[[SessionChangeEvent, SessionString], None]
-AsyncSessionChangeCallback = t.Callable[[SessionChangeEvent, SessionString], t.Coroutine[t.Any, t.Any, None]]
+SessionChangeCallback = t.Callable[[SessionEvent, Session], None]
+AsyncSessionChangeCallback = t.Callable[[SessionEvent, Session], t.Coroutine[t.Any, t.Any, None]]
+
+
+class SessionString(Session):
+    def __init_subclass__(cls, *args, **kwargs: t.Any) -> None:
+        import warnings
+
+        warnings.warn('SessionString class is deprecated. Use Session class instead.', DeprecationWarning, stacklevel=2)
+        super().__init_subclass__(*args, **kwargs)
+
+    def __init__(self, *args, **kwargs: t.Any) -> None:
+        import warnings
+
+        warnings.warn('SessionString class is deprecated. Use Session class instead.', DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)

--- a/packages/atproto_client/client/session.py
+++ b/packages/atproto_client/client/session.py
@@ -1,0 +1,52 @@
+import typing as t
+from dataclasses import dataclass
+from enum import Enum
+
+import typing_extensions as te
+
+if t.TYPE_CHECKING:
+    from atproto_client import models
+
+
+class SessionChangeEvent(Enum):
+    IMPORT = 'import'
+    CREATE = 'creat'
+    REFRESH = 'refresh'
+
+
+_SESSION_STRING_SEPARATOR: te.Final[te.Literal[':::']] = ':::'
+
+
+@dataclass
+class SessionString:
+    handle: str
+    did: str
+    access_jwt: str
+    refresh_jwt: str
+
+    def encode(self) -> str:
+        payload = [
+            self.handle,
+            self.did,
+            self.access_jwt,
+            self.refresh_jwt,
+        ]
+        return _SESSION_STRING_SEPARATOR.join(payload)
+
+    @classmethod
+    def decode(cls, session_string: str) -> 'SessionString':
+        handle, did, access_jwt, refresh_jwt = session_string.split(_SESSION_STRING_SEPARATOR)
+        return cls(handle, did, access_jwt, refresh_jwt)
+
+    def copy(self) -> 'SessionString':
+        return SessionString(self.handle, self.did, self.access_jwt, self.refresh_jwt)
+
+
+SessionResponse: te.TypeAlias = t.Union[
+    'models.ComAtprotoServerCreateSession.Response',
+    'models.ComAtprotoServerRefreshSession.Response',
+    'SessionString',
+]
+
+SessionChangeCallback = t.Callable[[SessionChangeEvent, SessionString], None]
+AsyncSessionChangeCallback = t.Callable[[SessionChangeEvent, SessionString], t.Coroutine[t.Any, t.Any, None]]

--- a/packages/atproto_codegen/clients/generate_async_client.py
+++ b/packages/atproto_codegen/clients/generate_async_client.py
@@ -14,8 +14,11 @@ def gen_client(input_filename: str, output_filename: str) -> None:
     methods = [
         'send_post',
         'send_image',
+        '_set_session',
         '_get_and_set_session',
         '_refresh_and_set_session',
+        '_import_session_string',
+        '_call_on_session_change_callbacks',
         '_invoke',
     ]
 
@@ -23,6 +26,7 @@ def gen_client(input_filename: str, output_filename: str) -> None:
     code = code.replace('client.raw', 'client.async_raw')
     code = code.replace('class Client', 'class AsyncClient')
     code = code.replace('ClientRaw', 'AsyncClientRaw')
+    code = code.replace('SessionDispatchMixin', 'AsyncSessionDispatchMixin')
 
     code = code.replace('with self', 'async with self')
 
@@ -33,8 +37,8 @@ def gen_client(input_filename: str, output_filename: str) -> None:
     code = code.replace('self.app', 'await self.app')
 
     for method in methods:
-        code = code.replace(f'self.{method}', f'await self.{method}')
-        code = code.replace(f'super().{method}', f'await super().{method}')
+        code = code.replace(f'self.{method}(', f'await self.{method}(')
+        code = code.replace(f'super().{method}(', f'await super().{method}(')
 
     code = DISCLAIMER + code
 


### PR DESCRIPTION
closes #268

Usage example:
```python
from atproto import Client, SessionEvent, Session


client = Client()

@client.on_session_change
def on_session_change(event: SessionEvent, session: Session) -> None:
    print(event, session)

# or without decorator:
# client.on_session_change(on_session_change)

client.login('handle', 'pass')
```

Async usage example:
```python
from atproto import AsyncClient, SessionEvent, Session

client = AsyncClient()

@client.on_session_change
async def on_session_change(event: SessionEvent, session: Session) -> None:
    print(event, session)

# or without decorator:
# client.on_session_change(on_session_change)

await client.login('handle', 'pass')
```