### PR TITLE
Add send_ogp_link_card (Open Graph protocol) example

### DIFF
--- a/examples/advanced_usage/send_ogp_link_card.py
+++ b/examples/advanced_usage/send_ogp_link_card.py
@@ -1,27 +1,47 @@
 import re
 import typing as t
-import urllib.request
 
+import httpx
 from atproto import Client, models
 
+_META_PATTERN = re.compile(r'<meta property="og:.*?>')
+_CONTENT_PATTERN = re.compile(r'<meta[^>]+content="([^"]+)"')
 
-def get_og_tags(url: str) -> t.Tuple[str, str, str]:
-    if not url.startswith(('http:', 'https:')):
-        raise ValueError("URL must start with 'http:' or 'https:'")
-    with urllib.request.urlopen(url) as res:
-        html = res.read().decode('utf-8')
-    meta_pattern = re.compile(r'<meta property="og:.*?>')
-    content_pattern = re.compile(r'<meta[^>]+content="([^"]+)"')
-    og_tags = meta_pattern.findall(html)
-    if not og_tags:
-        raise ValueError('og tags not found.')
 
-    og_image = next(filter(lambda x: 'og:image' in x, og_tags))
-    og_image = content_pattern.match(og_image).group(1)
-    og_title = next(filter(lambda x: 'og:title' in x, og_tags))
-    og_title = content_pattern.match(og_title).group(1)
-    og_description = next(filter(lambda x: 'og:description' in x, og_tags))
-    og_description = content_pattern.match(og_description).group(1)
+def _find_tag(og_tags: t.List[str], search_tag: str) -> t.Optional[str]:
+    for tag in og_tags:
+        if search_tag in tag:
+            return tag
+
+    return None
+
+
+def _get_tag_content(tag: str) -> t.Optional[str]:
+    match = _CONTENT_PATTERN.match(tag)
+    if match:
+        return match.group(1)
+
+    return None
+
+
+def _get_og_tag_value(og_tags: t.List[str], tag_name: str) -> t.Optional[str]:
+    tag = _find_tag(og_tags, tag_name)
+    if tag:
+        return _get_tag_content(tag)
+
+    return None
+
+
+def get_og_tags(url: str) -> t.Tuple[t.Optional[str], t.Optional[str], t.Optional[str]]:
+    response = httpx.get(url)
+    response.raise_for_status()
+
+    og_tags = _META_PATTERN.findall(response.text)
+
+    og_image = _get_og_tag_value(og_tags, 'og:image')
+    og_title = _get_og_tag_value(og_tags, 'og:title')
+    og_description = _get_og_tag_value(og_tags, 'og:description')
+
     return og_image, og_title, og_description
 
 
@@ -30,17 +50,21 @@ def main() -> None:
     client.login('my-handle', 'my-password')
 
     url = 'https://github.com/MarshalX/atproto'
-    text = 'Example post with embed external resource (link card) with og:image'
+    text = 'Example post with embed external resource (link card) with Open Graph Protocol (OGP) tags from the website'
 
-    # Download image from og:image url
     img_url, title, description = get_og_tags(url)
-    img_fp = urllib.request.urlopen(img_url)
-    thumb_ref = client.upload_blob(img_fp.read())
+    if title is None or description is None:
+        raise ValueError('Required Open Graph Protocol (OGP) tags not found')
+
+    thumb_blob = None
+    if img_url:
+        # Download image from og:image url and upload it as a blob
+        img_data = httpx.get(img_url).content
+        thumb_blob = client.upload_blob(img_data).blob
+
     # AppBskyEmbedExternal is the same as "link card" in the app
     embed_external = models.AppBskyEmbedExternal.Main(
-        external=models.AppBskyEmbedExternal.External(
-            title=title, description=description, uri=url, thumb=thumb_ref.blob
-        )
+        external=models.AppBskyEmbedExternal.External(title=title, description=description, uri=url, thumb=thumb_blob)
     )
     client.send_post(text=text, embed=embed_external)
 

--- a/examples/advanced_usage/send_ogp_link_card.py
+++ b/examples/advanced_usage/send_ogp_link_card.py
@@ -1,0 +1,49 @@
+import re
+import typing as t
+import urllib.request
+
+from atproto import Client, models
+
+
+def get_og_tags(url: str) -> t.Tuple[str, str, str]:
+    if not url.startswith(('http:', 'https:')):
+        raise ValueError("URL must start with 'http:' or 'https:'")
+    with urllib.request.urlopen(url) as res:
+        html = res.read().decode('utf-8')
+    meta_pattern = re.compile(r'<meta property="og:.*?>')
+    content_pattern = re.compile(r'<meta[^>]+content="([^"]+)"')
+    og_tags = meta_pattern.findall(html)
+    if not og_tags:
+        raise ValueError('og tags not found.')
+
+    og_image = next(filter(lambda x: 'og:image' in x, og_tags))
+    og_image = content_pattern.match(og_image).group(1)
+    og_title = next(filter(lambda x: 'og:title' in x, og_tags))
+    og_title = content_pattern.match(og_title).group(1)
+    og_description = next(filter(lambda x: 'og:description' in x, og_tags))
+    og_description = content_pattern.match(og_description).group(1)
+    return og_image, og_title, og_description
+
+
+def main() -> None:
+    client = Client()
+    client.login('my-handle', 'my-password')
+
+    url = 'https://github.com/MarshalX/atproto'
+    text = 'Example post with embed external resource (link card) with og:image'
+
+    # Download image from og:image url
+    img_url, title, description = get_og_tags(url)
+    img_fp = urllib.request.urlopen(img_url)
+    thumb_ref = client.upload_blob(img_fp.read())
+    # AppBskyEmbedExternal is the same as "link card" in the app
+    embed_external = models.AppBskyEmbedExternal.Main(
+        external=models.AppBskyEmbedExternal.External(
+            title=title, description=description, uri=url, thumb=thumb_ref.blob
+        )
+    )
+    client.send_post(text=text, embed=embed_external)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi, first of all, thank you for the wonderful project

Added an example of getting og:image from a site and posting a link card with an image.
Please merge if you like.

like this:

![2024-02-10 19_57_01-ホーム — Bluesky](https://github.com/MarshalX/atproto/assets/11247895/f7f0bb49-46a4-4ec4-a798-80ad1472716b)
