### PR TITLE
Add method to send post with multiple attached photos

### DIFF
--- a/examples/send_images.py
+++ b/examples/send_images.py
@@ -7,6 +7,8 @@ def main() -> None:
 
     # replace the path to your image file
     paths = ['cat.jpg', 'dog.jpg', 'bird.jpg']
+    image_alts = ['Text version', 'of the image (ALT)', 'This parameter is optional']
+
     images = []
     for path in paths:
         with open(path, 'rb') as f:
@@ -15,7 +17,7 @@ def main() -> None:
     client.send_images(
         text='Post with image from Python',
         images=images,
-        image_alts=['Text version', 'of the image (ALT)', 'This parameter is optional'])
+        image_alts=image_alts)
 
 
 if __name__ == '__main__':

--- a/examples/send_images.py
+++ b/examples/send_images.py
@@ -1,0 +1,22 @@
+from atproto import Client
+
+
+def main() -> None:
+    client = Client()
+    client.login('my-handle', 'my-password')
+
+    # replace the path to your image file
+    paths = ['cat.jpg', 'dog.jpg', 'bird.jpg']
+    images = []
+    for path in paths:
+        with open(path, 'rb') as f:
+            images.append(f.read())
+
+    client.send_images(
+        text='Post with image from Python',
+        images=images,
+        image_alts=['Text version', 'of the image (ALT)', 'This parameter is optional'])
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/send_images.py
+++ b/examples/send_images.py
@@ -14,10 +14,7 @@ def main() -> None:
         with open(path, 'rb') as f:
             images.append(f.read())
 
-    client.send_images(
-        text='Post with image from Python',
-        images=images,
-        image_alts=image_alts)
+    client.send_images(text='Post with image from Python', images=images, image_alts=image_alts)
 
 
 if __name__ == '__main__':

--- a/packages/atproto_client/client/async_client.py
+++ b/packages/atproto_client/client/async_client.py
@@ -4,6 +4,7 @@
 # This file is part of Python atproto SDK. Licenced under MIT.
 ##################################################################
 
+import asyncio
 import typing as t
 from asyncio import Lock
 
@@ -181,6 +182,58 @@ class AsyncClient(
         uri = AtUri.from_str(post_uri)
         return await self.app.bsky.feed.post.delete(uri.hostname, uri.rkey)
 
+    async def send_images(
+        self,
+        text: t.Union[str, TextBuilder],
+        images: t.List[bytes],
+        image_alts: t.Optional[t.List[str]] = None,
+        profile_identify: t.Optional[str] = None,
+        reply_to: t.Optional['models.AppBskyFeedPost.ReplyRef'] = None,
+        langs: t.Optional[t.List[str]] = None,
+        facets: t.Optional[t.List['models.AppBskyRichtextFacet.Main']] = None,
+    ) -> 'models.AppBskyFeedPost.CreateRecordResponse':
+        """Send post with multiple attached images (up to 4 images).
+
+        Note:
+            If `profile_identify` is not provided will be sent to the current profile.
+
+        Args:
+            text: Text of the post.
+            images: List of binary images to attach. The length must be less than or equal to 4.
+            image_alts: List of text version of the images.
+                        The length should be shorter than or equal to the length of `images`.
+            profile_identify: Handle or DID. Where to send post.
+            reply_to: Root and parent of the post to reply to.
+            langs: List of used languages in the post.
+            facets: List of facets (rich text items).
+
+        Returns:
+            :obj:`models.AppBskyFeedPost.CreateRecordResponse`: Reference to the created record.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        if image_alts is None:
+            image_alts = [''] * len(images)
+        else:
+            # padding with empty string if len is insufficient
+            diff = len(images) - len(image_alts)
+            image_alts = image_alts + [''] * diff  # [''] * (minus) => []
+
+        uploads = await asyncio.gather(*[self.upload_blob(image) for image in images])
+        embed_images = [
+            models.AppBskyEmbedImages.Image(alt=alt, image=upload.blob) for alt, upload in zip(image_alts, uploads)
+        ]
+
+        return await self.send_post(
+            text,
+            profile_identify=profile_identify,
+            reply_to=reply_to,
+            embed=models.AppBskyEmbedImages.Main(images=embed_images),
+            langs=langs,
+            facets=facets,
+        )
+
     async def send_image(
         self,
         text: t.Union[str, TextBuilder],
@@ -199,7 +252,7 @@ class AsyncClient(
         Args:
             text: Text of the post.
             image: Binary image to attach.
-            image_alt: Text version of the image
+            image_alt: Text version of the image.
             profile_identify: Handle or DID. Where to send post.
             reply_to: Root and parent of the post to reply to.
             langs: List of used languages in the post.
@@ -211,13 +264,12 @@ class AsyncClient(
         Raises:
             :class:`atproto.exceptions.AtProtocolError`: Base exception.
         """
-        upload = await self.com.atproto.repo.upload_blob(image)
-        images = [models.AppBskyEmbedImages.Image(alt=image_alt, image=upload.blob)]
-        return await self.send_post(
+        return await self.send_images(
             text,
+            images=[image],
+            image_alts=[image_alt],
             profile_identify=profile_identify,
             reply_to=reply_to,
-            embed=models.AppBskyEmbedImages.Main(images=images),
             langs=langs,
             facets=facets,
         )

--- a/packages/atproto_client/client/async_client.py
+++ b/packages/atproto_client/client/async_client.py
@@ -8,6 +8,7 @@ import typing as t
 from asyncio import Lock
 
 from atproto_core.uri import AtUri
+from atproto_core.exceptions import AtProtocolError
 
 from atproto_client import models
 from atproto_client.client.async_raw import AsyncClientRaw
@@ -181,6 +182,60 @@ class AsyncClient(
         uri = AtUri.from_str(post_uri)
         return await self.app.bsky.feed.post.delete(uri.hostname, uri.rkey)
 
+    async def send_images(
+        self,
+        text: t.Union[str, TextBuilder],
+        images: t.List[bytes],
+        image_alts: t.Optional[t.List[str]] = None,
+        profile_identify: t.Optional[str] = None,
+        reply_to: t.Optional['models.AppBskyFeedPost.ReplyRef'] = None,
+        langs: t.Optional[t.List[str]] = None,
+        facets: t.Optional[t.List['models.AppBskyRichtextFacet.Main']] = None,
+    ) -> 'models.AppBskyFeedPost.CreateRecordResponse':
+        """Send post with multiple attached images (up to 4 images).
+
+        Note:
+            If `profile_identify` is not provided will be sent to the current profile.
+
+        Args:
+            text: Text of the post.
+            images: List of binary images to attach. The length must be less than or equal to 4.
+            image_alts: List of text version of the images. The length must be equal to the length of `images`.
+            profile_identify: Handle or DID. Where to send post.
+            reply_to: Root and parent of the post to reply to.
+            langs: List of used languages in the post.
+            facets: List of facets (rich text items).
+
+        Returns:
+            :obj:`models.AppBskyFeedPost.CreateRecordResponse`: Reference to the created record.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        if image_alts is None:
+            image_alts = [""] * len(images)
+
+        # validation
+        if len(images) > 4:
+            raise AtProtocolError("The length of images must be less than or equal to 4.")
+        if len(images) != len(image_alts):
+            raise AtProtocolError("The lengths of images & image_alts must be equal.")
+
+        uploads = [await self.upload_blob(i) for i in images]
+        embed_images = [
+            models.AppBskyEmbedImages.Image(alt=a, image=u.blob)
+            for a, u in zip(image_alts, uploads)
+        ]
+
+        return await self.send_post(
+            text,
+            profile_identify=profile_identify,
+            reply_to=reply_to,
+            embed=models.AppBskyEmbedImages.Main(images=embed_images),
+            langs=langs,
+            facets=facets,
+        )
+
     async def send_image(
         self,
         text: t.Union[str, TextBuilder],
@@ -199,7 +254,7 @@ class AsyncClient(
         Args:
             text: Text of the post.
             image: Binary image to attach.
-            image_alt: Text version of the image
+            image_alt: Text version of the image.
             profile_identify: Handle or DID. Where to send post.
             reply_to: Root and parent of the post to reply to.
             langs: List of used languages in the post.
@@ -211,13 +266,12 @@ class AsyncClient(
         Raises:
             :class:`atproto.exceptions.AtProtocolError`: Base exception.
         """
-        upload = await self.com.atproto.repo.upload_blob(image)
-        images = [models.AppBskyEmbedImages.Image(alt=image_alt, image=upload.blob)]
-        return await self.send_post(
+        return await self.send_images(
             text,
+            images=[image],
+            image_alts=[image_alt],
             profile_identify=profile_identify,
             reply_to=reply_to,
-            embed=models.AppBskyEmbedImages.Main(images=images),
             langs=langs,
             facets=facets,
         )

--- a/packages/atproto_client/client/async_client.py
+++ b/packages/atproto_client/client/async_client.py
@@ -8,7 +8,6 @@ import typing as t
 from asyncio import Lock
 
 from atproto_core.uri import AtUri
-from atproto_core.exceptions import AtProtocolError
 
 from atproto_client import models
 from atproto_client.client.async_raw import AsyncClientRaw
@@ -182,60 +181,6 @@ class AsyncClient(
         uri = AtUri.from_str(post_uri)
         return await self.app.bsky.feed.post.delete(uri.hostname, uri.rkey)
 
-    async def send_images(
-        self,
-        text: t.Union[str, TextBuilder],
-        images: t.List[bytes],
-        image_alts: t.Optional[t.List[str]] = None,
-        profile_identify: t.Optional[str] = None,
-        reply_to: t.Optional['models.AppBskyFeedPost.ReplyRef'] = None,
-        langs: t.Optional[t.List[str]] = None,
-        facets: t.Optional[t.List['models.AppBskyRichtextFacet.Main']] = None,
-    ) -> 'models.AppBskyFeedPost.CreateRecordResponse':
-        """Send post with multiple attached images (up to 4 images).
-
-        Note:
-            If `profile_identify` is not provided will be sent to the current profile.
-
-        Args:
-            text: Text of the post.
-            images: List of binary images to attach. The length must be less than or equal to 4.
-            image_alts: List of text version of the images. The length must be equal to the length of `images`.
-            profile_identify: Handle or DID. Where to send post.
-            reply_to: Root and parent of the post to reply to.
-            langs: List of used languages in the post.
-            facets: List of facets (rich text items).
-
-        Returns:
-            :obj:`models.AppBskyFeedPost.CreateRecordResponse`: Reference to the created record.
-
-        Raises:
-            :class:`atproto.exceptions.AtProtocolError`: Base exception.
-        """
-        if image_alts is None:
-            image_alts = [""] * len(images)
-
-        # validation
-        if len(images) > 4:
-            raise AtProtocolError("The length of images must be less than or equal to 4.")
-        if len(images) != len(image_alts):
-            raise AtProtocolError("The lengths of images & image_alts must be equal.")
-
-        uploads = [await self.upload_blob(i) for i in images]
-        embed_images = [
-            models.AppBskyEmbedImages.Image(alt=a, image=u.blob)
-            for a, u in zip(image_alts, uploads)
-        ]
-
-        return await self.send_post(
-            text,
-            profile_identify=profile_identify,
-            reply_to=reply_to,
-            embed=models.AppBskyEmbedImages.Main(images=embed_images),
-            langs=langs,
-            facets=facets,
-        )
-
     async def send_image(
         self,
         text: t.Union[str, TextBuilder],
@@ -254,7 +199,7 @@ class AsyncClient(
         Args:
             text: Text of the post.
             image: Binary image to attach.
-            image_alt: Text version of the image.
+            image_alt: Text version of the image
             profile_identify: Handle or DID. Where to send post.
             reply_to: Root and parent of the post to reply to.
             langs: List of used languages in the post.
@@ -266,12 +211,13 @@ class AsyncClient(
         Raises:
             :class:`atproto.exceptions.AtProtocolError`: Base exception.
         """
-        return await self.send_images(
+        upload = await self.com.atproto.repo.upload_blob(image)
+        images = [models.AppBskyEmbedImages.Image(alt=image_alt, image=upload.blob)]
+        return await self.send_post(
             text,
-            images=[image],
-            image_alts=[image_alt],
             profile_identify=profile_identify,
             reply_to=reply_to,
+            embed=models.AppBskyEmbedImages.Main(images=images),
             langs=langs,
             facets=facets,
         )

--- a/packages/atproto_client/client/client.py
+++ b/packages/atproto_client/client/client.py
@@ -208,8 +208,6 @@ class Client(_BackwardCompatibility, SessionDispatchMixin, SessionMethodsMixin, 
             image_alts = [''] * len(images)
 
         # validation
-        if len(images) > 4:
-            raise AtProtocolError("The length of images must be less than or equal to 4.")
         if len(images) != len(image_alts):
             raise AtProtocolError('The lengths of images & image_alts must be equal.')
 

--- a/packages/atproto_client/client/client.py
+++ b/packages/atproto_client/client/client.py
@@ -1,8 +1,8 @@
 import typing as t
 from threading import Lock
 
-from atproto_core.uri import AtUri
 from atproto_core.exceptions import AtProtocolError
+from atproto_core.uri import AtUri
 
 from atproto_client import models
 from atproto_client.client.methods_mixin import SessionMethodsMixin, TimeMethodsMixin
@@ -205,13 +205,13 @@ class Client(_BackwardCompatibility, SessionDispatchMixin, SessionMethodsMixin, 
             :class:`atproto.exceptions.AtProtocolError`: Base exception.
         """
         if image_alts is None:
-            image_alts = [""] * len(images)
+            image_alts = [''] * len(images)
 
         # validation
         if len(images) > 4:
             raise AtProtocolError("The length of images must be less than or equal to 4.")
         if len(images) != len(image_alts):
-            raise AtProtocolError("The lengths of images & image_alts must be equal.")
+            raise AtProtocolError('The lengths of images & image_alts must be equal.')
 
         uploads = [self.upload_blob(i) for i in images]
         embed_images = [

--- a/packages/atproto_client/client/client.py
+++ b/packages/atproto_client/client/client.py
@@ -2,6 +2,7 @@ import typing as t
 from threading import Lock
 
 from atproto_core.uri import AtUri
+from atproto_core.exceptions import AtProtocolError
 
 from atproto_client import models
 from atproto_client.client.methods_mixin import SessionMethodsMixin, TimeMethodsMixin
@@ -173,6 +174,60 @@ class Client(_BackwardCompatibility, SessionDispatchMixin, SessionMethodsMixin, 
         uri = AtUri.from_str(post_uri)
         return self.app.bsky.feed.post.delete(uri.hostname, uri.rkey)
 
+    def send_images(
+        self,
+        text: t.Union[str, TextBuilder],
+        images: t.List[bytes],
+        image_alts: t.Optional[t.List[str]] = None,
+        profile_identify: t.Optional[str] = None,
+        reply_to: t.Optional['models.AppBskyFeedPost.ReplyRef'] = None,
+        langs: t.Optional[t.List[str]] = None,
+        facets: t.Optional[t.List['models.AppBskyRichtextFacet.Main']] = None,
+    ) -> 'models.AppBskyFeedPost.CreateRecordResponse':
+        """Send post with multiple attached images (up to 4 images).
+
+        Note:
+            If `profile_identify` is not provided will be sent to the current profile.
+
+        Args:
+            text: Text of the post.
+            images: List of binary images to attach. The length must be less than or equal to 4.
+            image_alts: List of text version of the images. The length must be equal to the length of `images`.
+            profile_identify: Handle or DID. Where to send post.
+            reply_to: Root and parent of the post to reply to.
+            langs: List of used languages in the post.
+            facets: List of facets (rich text items).
+
+        Returns:
+            :obj:`models.AppBskyFeedPost.CreateRecordResponse`: Reference to the created record.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        if image_alts is None:
+            image_alts = [""] * len(images)
+
+        # validation
+        if len(images) > 4:
+            raise AtProtocolError("The length of images must be less than or equal to 4.")
+        if len(images) != len(image_alts):
+            raise AtProtocolError("The lengths of images & image_alts must be equal.")
+
+        uploads = [self.upload_blob(i) for i in images]
+        embed_images = [
+            models.AppBskyEmbedImages.Image(alt=a, image=u.blob)
+            for a, u in zip(image_alts, uploads)
+        ]
+
+        return self.send_post(
+            text,
+            profile_identify=profile_identify,
+            reply_to=reply_to,
+            embed=models.AppBskyEmbedImages.Main(images=embed_images),
+            langs=langs,
+            facets=facets,
+        )
+
     def send_image(
         self,
         text: t.Union[str, TextBuilder],
@@ -191,7 +246,7 @@ class Client(_BackwardCompatibility, SessionDispatchMixin, SessionMethodsMixin, 
         Args:
             text: Text of the post.
             image: Binary image to attach.
-            image_alt: Text version of the image
+            image_alt: Text version of the image.
             profile_identify: Handle or DID. Where to send post.
             reply_to: Root and parent of the post to reply to.
             langs: List of used languages in the post.
@@ -203,13 +258,12 @@ class Client(_BackwardCompatibility, SessionDispatchMixin, SessionMethodsMixin, 
         Raises:
             :class:`atproto.exceptions.AtProtocolError`: Base exception.
         """
-        upload = self.com.atproto.repo.upload_blob(image)
-        images = [models.AppBskyEmbedImages.Image(alt=image_alt, image=upload.blob)]
-        return self.send_post(
+        return self.send_images(
             text,
+            images=[image],
+            image_alts=[image_alt],
             profile_identify=profile_identify,
             reply_to=reply_to,
-            embed=models.AppBskyEmbedImages.Main(images=images),
             langs=langs,
             facets=facets,
         )

--- a/packages/atproto_codegen/clients/generate_async_client.py
+++ b/packages/atproto_codegen/clients/generate_async_client.py
@@ -23,7 +23,7 @@ def gen_client(input_filename: str, output_filename: str) -> None:
         '_invoke',
     ]
 
-    code = code.replace('from threading', 'from asyncio')
+    code = code.replace('from threading', 'import asyncio\nfrom asyncio')
     code = code.replace('client.raw', 'client.async_raw')
     code = code.replace('class Client', 'class AsyncClient')
     code = code.replace('ClientRaw', 'AsyncClientRaw')
@@ -41,11 +41,7 @@ def gen_client(input_filename: str, output_filename: str) -> None:
         code = code.replace(f'self.{method}(', f'await self.{method}(')
         code = code.replace(f'super().{method}(', f'await super().{method}(')
 
-    code = code.replace('from asyncio', 'import asyncio\nfrom asyncio')
-    code = re.sub(
-        r'(\[self\.upload_blob.*\])',
-        r'await asyncio.gather(*\1)',
-        code)
+    code = re.sub(r'(\[self\.upload_blob.*\])', r'await asyncio.gather(*\1)', code)
 
     code = DISCLAIMER + code
 

--- a/packages/atproto_codegen/clients/generate_async_client.py
+++ b/packages/atproto_codegen/clients/generate_async_client.py
@@ -15,6 +15,7 @@ def gen_client(input_filename: str, output_filename: str) -> None:
     methods = [
         'send_post',
         'send_image',
+        'send_images',
         '_set_session',
         '_get_and_set_session',
         '_refresh_and_set_session',

--- a/packages/atproto_codegen/clients/generate_async_client.py
+++ b/packages/atproto_codegen/clients/generate_async_client.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from atproto_codegen.consts import DISCLAIMER
@@ -39,6 +40,12 @@ def gen_client(input_filename: str, output_filename: str) -> None:
     for method in methods:
         code = code.replace(f'self.{method}(', f'await self.{method}(')
         code = code.replace(f'super().{method}(', f'await super().{method}(')
+
+    code = code.replace('from asyncio', 'import asyncio\nfrom asyncio')
+    code = re.sub(
+        r'(\[self\.upload_blob.*\])',
+        r'await asyncio.gather(*\1)',
+        code)
 
     code = DISCLAIMER + code
 


### PR DESCRIPTION
## Description
I've added a function `send_images` to send a post with multiple attached images.

## Changes
- Add function `send_images` to class Client & AsyncClient
- Rewrite function `send_image` using `send_images` (to keep backward compatibility)
- Add an example of usage of `send_images`