### PR TITLE
Fix typo in item of `SessionEvent`: `'creat'` -> `'create'`

### DIFF
--- a/packages/atproto_client/client/session.py
+++ b/packages/atproto_client/client/session.py
@@ -11,7 +11,7 @@ if t.TYPE_CHECKING:
 
 class SessionEvent(Enum):
     IMPORT = 'import'
-    CREATE = 'creat'
+    CREATE = 'create'
     REFRESH = 'refresh'
 
 


### PR DESCRIPTION
I did not see any other instances of this