### PR TITLE
Fix link to API docs for rate-limits in atproto_client/auth.md

### DIFF
--- a/docs/source/atproto_client/auth.md
+++ b/docs/source/atproto_client/auth.md
@@ -32,7 +32,7 @@ For example, instead of starting the script by `cron` every 5 minutes, keep it r
 This is incredibly important because API is rate-limited, and you can reach the limit. 
 Which can lead to a temporary outage of your project.
 
-The current rate limits are provided in the [API documentation](https://www.docs.bsky.app/docs/advanced-guides/rate-limits).
+The current rate limits are provided in the [API documentation](https://docs.bsky.app/docs/advanced-guides/rate-limits).
 
 - `createSession`:
   - Rate limited by handle


### PR DESCRIPTION
The link to the Bluesky API documentation for rate limiting has an unneeded `www.` in the Client (API) / Auth Markdown file.