### PR TITLE
Add documentation for string formats; fix `at-identifier` format

### DIFF
--- a/docs/source/alias_resolver.py
+++ b/docs/source/alias_resolver.py
@@ -14,8 +14,21 @@ if t.TYPE_CHECKING:
 # FIXME(MarshalX): I didn't find a fast way to fix aliases resolving after migration to Pydantic.
 #  I hope this is temporary and resolving will be on the Sphinx side.
 
+_GLOBAL_ALIASES_DB = {
+    'string_formats.validate_at_uri': 'atproto_client.models.string_formats.validate_at_uri',
+    'string_formats.validate_cid': 'atproto_client.models.string_formats.validate_cid',
+    'string_formats.validate_datetime': 'atproto_client.models.string_formats.validate_datetime',
+    'string_formats.validate_did': 'atproto_client.models.string_formats.validate_did',
+    'string_formats.validate_handle': 'atproto_client.models.string_formats.validate_handle',
+    'string_formats.validate_language': 'atproto_client.models.string_formats.validate_language',
+    'string_formats.validate_nsid': 'atproto_client.models.string_formats.validate_nsid',
+    'string_formats.validate_record_key': 'atproto_client.models.string_formats.validate_record_key',
+    'string_formats.validate_tid': 'atproto_client.models.string_formats.validate_tid',
+    'string_formats.validate_uri': 'atproto_client.models.string_formats.validate_uri',
+}
 
-def get_alias_from_db(alias: str) -> t.Optional[str]:
+
+def _get_model_alias(alias: str) -> t.Optional[str]:
     # FIXME(MarshalX): Resolving of models.AppBskyGraphDefs ListPurpose is not working.
     alias_split = alias.rsplit('.', maxsplit=1)
     if len(alias_split) < 2:
@@ -26,6 +39,14 @@ def get_alias_from_db(alias: str) -> t.Optional[str]:
         return None
 
     return f'{ALIASES_DB[alias_prefix]}.{alias_suffix}'
+
+
+def get_alias_from_db(alias: str) -> t.Optional[str]:
+    model_alias = _get_model_alias(alias)
+    if model_alias:
+        return model_alias
+
+    return _GLOBAL_ALIASES_DB.get(alias)
 
 
 # annotate

--- a/docs/source/atproto_client/index.rst
+++ b/docs/source/atproto_client/index.rst
@@ -16,4 +16,5 @@ Submodules
    namespace
    models
    auth
+   string_formats
    utils/index

--- a/docs/source/atproto_client/models.rst
+++ b/docs/source/atproto_client/models.rst
@@ -19,3 +19,4 @@ Submodules
    ../atproto/atproto_client.models.blob_ref
    ../atproto/atproto_client.models.dot_dict
    ../atproto/atproto_client.models.utils
+   ../atproto/atproto_client.models.string_formats

--- a/docs/source/atproto_client/string_formats.md
+++ b/docs/source/atproto_client/string_formats.md
@@ -119,7 +119,7 @@ from atproto_client.models.string_formats import Handle
 class MyModel(BaseModel):
     handle: Handle
 
-model = MyModel.model_validate(
+model_instance = MyModel.model_validate(
     {"handle": "alice.bsky.social"},
     context={"strict_string_format": True}
 )

--- a/docs/source/atproto_client/string_formats.md
+++ b/docs/source/atproto_client/string_formats.md
@@ -6,38 +6,6 @@ The AT Protocol defines several string formats that are used throughout the prot
 
 The SDK provides optional strict validation for AT Protocol string formats. By default, validation is disabled for performance reasons, but you can enable it when needed.
 
-### Validation Examples
-
-Using `Handle` as an example, here are the four main validation cases:
-
-```python
-from pydantic import TypeAdapter
-from atproto_client.models.string_formats import Handle
-
-HandleAdapter = TypeAdapter(Handle)
-
-# Case 1: Valid handle without validation (passes)
-handle1 = HandleAdapter.validate_python("alice.bsky.social")
-
-# Case 2: Valid handle with validation (passes)
-handle2 = HandleAdapter.validate_python(
-    "alice.bsky.social",
-    context={"strict_string_format": True}
-)
-
-# Case 3: Invalid handle without validation (passes)
-handle3 = HandleAdapter.validate_python("not a valid handle!")
-
-# Case 4: Invalid handle with validation (raises ValidationError)
-try:
-    HandleAdapter.validate_python(
-        "not a valid handle!",
-        context={"strict_string_format": True}
-    )
-except ValidationError as e:
-    print("Validation failed:", e)
-```
-
 ### Supported String Formats
 
 The SDK supports validation of the following string formats:
@@ -45,9 +13,9 @@ The SDK supports validation of the following string formats:
 :::{attention}
 These formats are a working empirical understanding of the required formats based on the following resources:
 
-- https://atproto.com/specs/lexicon
+- [AT Protocol Lexicon](https://atproto.com/specs/lexicon)
 
-- https://github.com/bluesky-social/atproto/tree/main/interop-test-files/syntax
+- [AT Protocol Interoperability Test Files](https://github.com/bluesky-social/atproto/tree/main/interop-test-files/syntax)
 
 :::
 
@@ -139,10 +107,10 @@ class MyModel(BaseModel):
     handle: Handle
 
 data = {"handle": "alice.bsky.social"}
-model = get_or_create(data, MyModel, strict_string_format=True)
+model_instance = get_or_create(data, MyModel, strict_string_format=True)
 ```
 
-2. Using Pydantic's validation context:
+2. Using Pydantic's validation context directly:
 
 ```python
 from pydantic import BaseModel
@@ -157,4 +125,4 @@ model = MyModel.model_validate(
 )
 ```
 
-When validation is disabled (the default), any string value will be accepted. When enabled, the values must conform to the above validation rules, or else a `ValidationError` will be raised.
+When validation is disabled (the default), any string value will be accepted for any format. When enabled, the values must conform to the above validation rules, or else a `ValidationError` will be raised.

--- a/docs/source/atproto_client/string_formats.md
+++ b/docs/source/atproto_client/string_formats.md
@@ -67,13 +67,13 @@ Requirements:
 - Valid fractional seconds format if used
 - No whitespace allowed
 
-#### TID (Temporal ID)
+#### TID (Timestamp Identifiers)
 Must be:
 - Exactly 13 characters
 - Only lowercase letters and numbers 2-7
 - First byte's high bit (0x40) must be 0
 
-#### Record Key
+#### Record Key (rkey)
 A record key must:
 - Be 1-512 characters
 - Contain only alphanumeric chars, dots, underscores, colons, tildes, or hyphens

--- a/docs/source/atproto_client/string_formats.md
+++ b/docs/source/atproto_client/string_formats.md
@@ -1,0 +1,160 @@
+## String Formats
+
+The AT Protocol defines several string formats that are used throughout the protocol. This page describes these formats and how to validate them in your code.
+
+### Overview
+
+The SDK provides optional strict validation for AT Protocol string formats. By default, validation is disabled for performance reasons, but you can enable it when needed.
+
+### Validation Examples
+
+Using `Handle` as an example, here are the four main validation cases:
+
+```python
+from pydantic import TypeAdapter
+from atproto_client.models.string_formats import Handle
+
+HandleAdapter = TypeAdapter(Handle)
+
+# Case 1: Valid handle without validation (passes)
+handle1 = HandleAdapter.validate_python("alice.bsky.social")
+
+# Case 2: Valid handle with validation (passes)
+handle2 = HandleAdapter.validate_python(
+    "alice.bsky.social",
+    context={"strict_string_format": True}
+)
+
+# Case 3: Invalid handle without validation (passes)
+handle3 = HandleAdapter.validate_python("not a valid handle!")
+
+# Case 4: Invalid handle with validation (raises ValidationError)
+try:
+    HandleAdapter.validate_python(
+        "not a valid handle!",
+        context={"strict_string_format": True}
+    )
+except ValidationError as e:
+    print("Validation failed:", e)
+```
+
+### Supported String Formats
+
+The SDK supports validation of the following string formats:
+
+:::{attention}
+These formats are a working empirical understanding of the required formats based on the following resources:
+
+- https://atproto.com/specs/lexicon
+
+- https://github.com/bluesky-social/atproto/tree/main/interop-test-files/syntax
+
+:::
+
+
+#### Handle
+A handle must be a valid domain name (e.g., `user.bsky.social`):
+- 2+ segments separated by dots
+- ASCII alphanumeric characters and hyphens only
+- 1-63 chars per segment
+- Max 253 chars total
+- Last segment cannot start with a digit
+
+#### DID (Decentralized Identifier)
+A DID follows the pattern `did:method:identifier`:
+- Method must be lowercase letters
+- Identifier allows alphanumeric chars, dots, underscores, hyphens, and percent
+- Max 2KB length
+- No /?#[]@ characters allowed
+
+#### NSID (Namespaced Identifier)
+An NSID must have:
+- 3+ segments separated by dots
+- Reversed domain name (lowercase alphanumeric + hyphen)
+- Name segment (letters only)
+- Max 317 chars total
+- No segments ending in numbers
+- No @_*#! special characters
+- Max 63 chars per segment
+
+#### AT-URI
+An AT-URI must follow the pattern `at://authority/collection/record-key`:
+- Starts with `at://`
+- Contains handle or DID
+- Optional /collection/record-key path
+- Max 8KB length
+- No query parameters or fragments
+
+#### CID (Content Identifier)
+Must be:
+- Minimum 8 characters
+- Alphanumeric characters and plus signs only
+
+#### DateTime
+Requirements:
+- Must use uppercase T as time separator
+- Must include seconds (HH:MM:SS)
+- Must have timezone (Z or ±HH:MM)
+- No -00:00 timezone allowed
+- Valid fractional seconds format if used
+- No whitespace allowed
+
+#### TID (Temporal ID)
+Must be:
+- Exactly 13 characters
+- Only lowercase letters and numbers 2-7
+- First byte's high bit (0x40) must be 0
+
+#### Record Key
+A record key must:
+- Be 1-512 characters
+- Contain only alphanumeric chars, dots, underscores, colons, tildes, or hyphens
+- Not be "." or ".."
+
+#### URI
+Requirements:
+- Must have a scheme starting with a letter
+- Must have authority (netloc) or path/query/fragment
+- Max 8KB length
+- No spaces allowed
+- Must follow RFC-3986 format
+
+#### Language
+Must match pattern:
+- 2-3 letter language code or 'i'
+- Optional subtag with alphanumeric chars and hyphens
+
+### Using Validation in Your Code
+
+There are two ways to enable validation:
+
+1. Using `get_or_create` with `strict_string_format=True`:
+
+```python
+from atproto_client.models.utils import get_or_create
+from atproto_client.models.string_formats import Handle
+from pydantic import BaseModel
+
+class MyModel(BaseModel):
+    handle: Handle
+
+data = {"handle": "alice.bsky.social"}
+model = get_or_create(data, MyModel, strict_string_format=True)
+```
+
+2. Using Pydantic's validation context:
+
+```python
+from pydantic import BaseModel
+from atproto_client.models.string_formats import Handle
+
+class MyModel(BaseModel):
+    handle: Handle
+
+model = MyModel.model_validate(
+    {"handle": "alice.bsky.social"},
+    context={"strict_string_format": True}
+)
+```
+
+When validation is disabled (the default), any string value will be accepted. When enabled, the values must conform to the above validation rules, or else a `ValidationError` will be raised.

--- a/packages/atproto_client/models/app/bsky/actor/get_profile.py
+++ b/packages/atproto_client/models/app/bsky/actor/get_profile.py
@@ -13,8 +13,8 @@ from atproto_client.models import base, string_formats
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.actor.getProfile`."""
 
-    actor: string_formats.Handle  #: Handle or DID of account to fetch profile of.
+    actor: string_formats.AtIdentifier  #: Handle or DID of account to fetch profile of.
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: Handle or DID of account to fetch profile of.
+    actor: string_formats.AtIdentifier  #: Handle or DID of account to fetch profile of.

--- a/packages/atproto_client/models/app/bsky/actor/get_profiles.py
+++ b/packages/atproto_client/models/app/bsky/actor/get_profiles.py
@@ -19,11 +19,11 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.actor.getProfiles`."""
 
-    actors: t.List[string_formats.Handle] = Field(max_length=25)  #: Actors.
+    actors: t.List[string_formats.AtIdentifier] = Field(max_length=25)  #: Actors.
 
 
 class ParamsDict(t.TypedDict):
-    actors: t.List[string_formats.Handle]  #: Actors.
+    actors: t.List[string_formats.AtIdentifier]  #: Actors.
 
 
 class Response(base.ResponseModelBase):

--- a/packages/atproto_client/models/app/bsky/feed/get_actor_feeds.py
+++ b/packages/atproto_client/models/app/bsky/feed/get_actor_feeds.py
@@ -20,13 +20,13 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.feed.getActorFeeds`."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: t.Optional[str] = None  #: Cursor.
     limit: t.Optional[int] = Field(default=50, ge=1, le=100)  #: Limit.
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: te.NotRequired[t.Optional[str]]  #: Cursor.
     limit: te.NotRequired[t.Optional[int]]  #: Limit.
 

--- a/packages/atproto_client/models/app/bsky/feed/get_actor_likes.py
+++ b/packages/atproto_client/models/app/bsky/feed/get_actor_likes.py
@@ -20,13 +20,13 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.feed.getActorLikes`."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: t.Optional[str] = None  #: Cursor.
     limit: t.Optional[int] = Field(default=50, ge=1, le=100)  #: Limit.
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: te.NotRequired[t.Optional[str]]  #: Cursor.
     limit: te.NotRequired[t.Optional[int]]  #: Limit.
 

--- a/packages/atproto_client/models/app/bsky/feed/get_author_feed.py
+++ b/packages/atproto_client/models/app/bsky/feed/get_author_feed.py
@@ -20,7 +20,7 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.feed.getAuthorFeed`."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: t.Optional[str] = None  #: Cursor.
     filter: t.Optional[
         t.Union[
@@ -36,7 +36,7 @@ class Params(base.ParamsModelBase):
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: te.NotRequired[t.Optional[str]]  #: Cursor.
     filter: te.NotRequired[
         t.Optional[

--- a/packages/atproto_client/models/app/bsky/feed/search_posts.py
+++ b/packages/atproto_client/models/app/bsky/feed/search_posts.py
@@ -21,7 +21,7 @@ class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.feed.searchPosts`."""
 
     q: str  #: Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.
-    author: t.Optional[string_formats.Handle] = (
+    author: t.Optional[string_formats.AtIdentifier] = (
         None  #: Filter to posts by the given account. Handles are resolved to DID before query-time.
     )
     cursor: t.Optional[str] = (
@@ -34,7 +34,7 @@ class Params(base.ParamsModelBase):
         None  #: Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.
     )
     limit: t.Optional[int] = Field(default=25, ge=1, le=100)  #: Limit.
-    mentions: t.Optional[string_formats.Handle] = (
+    mentions: t.Optional[string_formats.AtIdentifier] = (
         None  #: Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.
     )
     since: t.Optional[str] = (
@@ -57,7 +57,7 @@ class Params(base.ParamsModelBase):
 class ParamsDict(t.TypedDict):
     q: str  #: Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.
     author: te.NotRequired[
-        t.Optional[string_formats.Handle]
+        t.Optional[string_formats.AtIdentifier]
     ]  #: Filter to posts by the given account. Handles are resolved to DID before query-time.
     cursor: te.NotRequired[
         t.Optional[str]
@@ -70,7 +70,7 @@ class ParamsDict(t.TypedDict):
     ]  #: Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.
     limit: te.NotRequired[t.Optional[int]]  #: Limit.
     mentions: te.NotRequired[
-        t.Optional[string_formats.Handle]
+        t.Optional[string_formats.AtIdentifier]
     ]  #: Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.
     since: te.NotRequired[
         t.Optional[str]

--- a/packages/atproto_client/models/app/bsky/graph/defs.py
+++ b/packages/atproto_client/models/app/bsky/graph/defs.py
@@ -141,7 +141,7 @@ class ListViewerState(base.ModelBase):
 class NotFoundActor(base.ModelBase):
     """Definition model for :obj:`app.bsky.graph.defs`. indicates that a handle or DID could not be resolved."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     not_found: bool = Field(frozen=True)  #: Not found.
 
     py_type: t.Literal['app.bsky.graph.defs#notFoundActor'] = Field(

--- a/packages/atproto_client/models/app/bsky/graph/get_actor_starter_packs.py
+++ b/packages/atproto_client/models/app/bsky/graph/get_actor_starter_packs.py
@@ -20,13 +20,13 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.graph.getActorStarterPacks`."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: t.Optional[str] = None  #: Cursor.
     limit: t.Optional[int] = Field(default=50, ge=1, le=100)  #: Limit.
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: te.NotRequired[t.Optional[str]]  #: Cursor.
     limit: te.NotRequired[t.Optional[int]]  #: Limit.
 

--- a/packages/atproto_client/models/app/bsky/graph/get_followers.py
+++ b/packages/atproto_client/models/app/bsky/graph/get_followers.py
@@ -20,13 +20,13 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.graph.getFollowers`."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: t.Optional[str] = None  #: Cursor.
     limit: t.Optional[int] = Field(default=50, ge=1, le=100)  #: Limit.
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: te.NotRequired[t.Optional[str]]  #: Cursor.
     limit: te.NotRequired[t.Optional[int]]  #: Limit.
 

--- a/packages/atproto_client/models/app/bsky/graph/get_follows.py
+++ b/packages/atproto_client/models/app/bsky/graph/get_follows.py
@@ -20,13 +20,13 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.graph.getFollows`."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: t.Optional[str] = None  #: Cursor.
     limit: t.Optional[int] = Field(default=50, ge=1, le=100)  #: Limit.
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: te.NotRequired[t.Optional[str]]  #: Cursor.
     limit: te.NotRequired[t.Optional[int]]  #: Limit.
 

--- a/packages/atproto_client/models/app/bsky/graph/get_known_followers.py
+++ b/packages/atproto_client/models/app/bsky/graph/get_known_followers.py
@@ -20,13 +20,13 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.graph.getKnownFollowers`."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: t.Optional[str] = None  #: Cursor.
     limit: t.Optional[int] = Field(default=50, ge=1, le=100)  #: Limit.
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
     cursor: te.NotRequired[t.Optional[str]]  #: Cursor.
     limit: te.NotRequired[t.Optional[int]]  #: Limit.
 

--- a/packages/atproto_client/models/app/bsky/graph/get_lists.py
+++ b/packages/atproto_client/models/app/bsky/graph/get_lists.py
@@ -20,13 +20,13 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.graph.getLists`."""
 
-    actor: string_formats.Handle  #: The account (actor) to enumerate lists from.
+    actor: string_formats.AtIdentifier  #: The account (actor) to enumerate lists from.
     cursor: t.Optional[str] = None  #: Cursor.
     limit: t.Optional[int] = Field(default=50, ge=1, le=100)  #: Limit.
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: The account (actor) to enumerate lists from.
+    actor: string_formats.AtIdentifier  #: The account (actor) to enumerate lists from.
     cursor: te.NotRequired[t.Optional[str]]  #: Cursor.
     limit: te.NotRequired[t.Optional[int]]  #: Limit.
 

--- a/packages/atproto_client/models/app/bsky/graph/get_relationships.py
+++ b/packages/atproto_client/models/app/bsky/graph/get_relationships.py
@@ -20,16 +20,16 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.graph.getRelationships`."""
 
-    actor: string_formats.Handle  #: Primary account requesting relationships for.
-    others: t.Optional[t.List[string_formats.Handle]] = Field(
+    actor: string_formats.AtIdentifier  #: Primary account requesting relationships for.
+    others: t.Optional[t.List[string_formats.AtIdentifier]] = Field(
         default=None, max_length=30
     )  #: List of 'other' accounts to be related back to the primary.
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: Primary account requesting relationships for.
+    actor: string_formats.AtIdentifier  #: Primary account requesting relationships for.
     others: te.NotRequired[
-        t.Optional[t.List[string_formats.Handle]]
+        t.Optional[t.List[string_formats.AtIdentifier]]
     ]  #: List of 'other' accounts to be related back to the primary.
 
 

--- a/packages/atproto_client/models/app/bsky/graph/get_suggested_follows_by_actor.py
+++ b/packages/atproto_client/models/app/bsky/graph/get_suggested_follows_by_actor.py
@@ -17,11 +17,11 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.graph.getSuggestedFollowsByActor`."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
 
 
 class ParamsDict(t.TypedDict):
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
 
 
 class Response(base.ResponseModelBase):

--- a/packages/atproto_client/models/app/bsky/graph/mute_actor.py
+++ b/packages/atproto_client/models/app/bsky/graph/mute_actor.py
@@ -13,8 +13,8 @@ from atproto_client.models import base, string_formats
 class Data(base.DataModelBase):
     """Input data model for :obj:`app.bsky.graph.muteActor`."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
 
 
 class DataDict(t.TypedDict):
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.

--- a/packages/atproto_client/models/app/bsky/graph/unmute_actor.py
+++ b/packages/atproto_client/models/app/bsky/graph/unmute_actor.py
@@ -13,8 +13,8 @@ from atproto_client.models import base, string_formats
 class Data(base.DataModelBase):
     """Input data model for :obj:`app.bsky.graph.unmuteActor`."""
 
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.
 
 
 class DataDict(t.TypedDict):
-    actor: string_formats.Handle  #: Actor.
+    actor: string_formats.AtIdentifier  #: Actor.

--- a/packages/atproto_client/models/app/bsky/unspecced/search_posts_skeleton.py
+++ b/packages/atproto_client/models/app/bsky/unspecced/search_posts_skeleton.py
@@ -21,7 +21,7 @@ class Params(base.ParamsModelBase):
     """Parameters model for :obj:`app.bsky.unspecced.searchPostsSkeleton`."""
 
     q: str  #: Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.
-    author: t.Optional[string_formats.Handle] = (
+    author: t.Optional[string_formats.AtIdentifier] = (
         None  #: Filter to posts by the given account. Handles are resolved to DID before query-time.
     )
     cursor: t.Optional[str] = (
@@ -34,7 +34,7 @@ class Params(base.ParamsModelBase):
         None  #: Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.
     )
     limit: t.Optional[int] = Field(default=25, ge=1, le=100)  #: Limit.
-    mentions: t.Optional[string_formats.Handle] = (
+    mentions: t.Optional[string_formats.AtIdentifier] = (
         None  #: Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.
     )
     since: t.Optional[str] = (
@@ -60,7 +60,7 @@ class Params(base.ParamsModelBase):
 class ParamsDict(t.TypedDict):
     q: str  #: Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.
     author: te.NotRequired[
-        t.Optional[string_formats.Handle]
+        t.Optional[string_formats.AtIdentifier]
     ]  #: Filter to posts by the given account. Handles are resolved to DID before query-time.
     cursor: te.NotRequired[
         t.Optional[str]
@@ -73,7 +73,7 @@ class ParamsDict(t.TypedDict):
     ]  #: Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.
     limit: te.NotRequired[t.Optional[int]]  #: Limit.
     mentions: te.NotRequired[
-        t.Optional[string_formats.Handle]
+        t.Optional[string_formats.AtIdentifier]
     ]  #: Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.
     since: te.NotRequired[
         t.Optional[str]

--- a/packages/atproto_client/models/com/atproto/admin/update_account_email.py
+++ b/packages/atproto_client/models/com/atproto/admin/update_account_email.py
@@ -13,10 +13,10 @@ from atproto_client.models import base, string_formats
 class Data(base.DataModelBase):
     """Input data model for :obj:`com.atproto.admin.updateAccountEmail`."""
 
-    account: string_formats.Handle  #: The handle or DID of the repo.
+    account: string_formats.AtIdentifier  #: The handle or DID of the repo.
     email: str  #: Email.
 
 
 class DataDict(t.TypedDict):
-    account: string_formats.Handle  #: The handle or DID of the repo.
+    account: string_formats.AtIdentifier  #: The handle or DID of the repo.
     email: str  #: Email.

--- a/packages/atproto_client/models/com/atproto/repo/apply_writes.py
+++ b/packages/atproto_client/models/com/atproto/repo/apply_writes.py
@@ -21,7 +21,7 @@ from atproto_client.models import base
 class Data(base.DataModelBase):
     """Input data model for :obj:`com.atproto.repo.applyWrites`."""
 
-    repo: string_formats.Handle  #: The handle or DID of the repo (aka, current account).
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo (aka, current account).
     writes: t.List[
         te.Annotated[
             t.Union[
@@ -41,7 +41,7 @@ class Data(base.DataModelBase):
 
 
 class DataDict(t.TypedDict):
-    repo: string_formats.Handle  #: The handle or DID of the repo (aka, current account).
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo (aka, current account).
     writes: t.List[
         te.Annotated[
             t.Union[

--- a/packages/atproto_client/models/com/atproto/repo/create_record.py
+++ b/packages/atproto_client/models/com/atproto/repo/create_record.py
@@ -23,7 +23,7 @@ class Data(base.DataModelBase):
 
     collection: string_formats.Nsid  #: The NSID of the record collection.
     record: 'UnknownInputType'  #: The record itself. Must contain a $type field.
-    repo: string_formats.Handle  #: The handle or DID of the repo (aka, current account).
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo (aka, current account).
     rkey: t.Optional[str] = Field(default=None, max_length=512)  #: The Record Key.
     swap_commit: t.Optional[string_formats.Cid] = None  #: Compare and swap with the previous commit by CID.
     validate_: t.Optional[bool] = (
@@ -34,7 +34,7 @@ class Data(base.DataModelBase):
 class DataDict(t.TypedDict):
     collection: string_formats.Nsid  #: The NSID of the record collection.
     record: 'UnknownInputType'  #: The record itself. Must contain a $type field.
-    repo: string_formats.Handle  #: The handle or DID of the repo (aka, current account).
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo (aka, current account).
     rkey: te.NotRequired[t.Optional[str]]  #: The Record Key.
     swap_commit: te.NotRequired[t.Optional[string_formats.Cid]]  #: Compare and swap with the previous commit by CID.
     validate: te.NotRequired[

--- a/packages/atproto_client/models/com/atproto/repo/delete_record.py
+++ b/packages/atproto_client/models/com/atproto/repo/delete_record.py
@@ -20,7 +20,7 @@ class Data(base.DataModelBase):
     """Input data model for :obj:`com.atproto.repo.deleteRecord`."""
 
     collection: string_formats.Nsid  #: The NSID of the record collection.
-    repo: string_formats.Handle  #: The handle or DID of the repo (aka, current account).
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo (aka, current account).
     rkey: str  #: The Record Key.
     swap_commit: t.Optional[string_formats.Cid] = None  #: Compare and swap with the previous commit by CID.
     swap_record: t.Optional[string_formats.Cid] = None  #: Compare and swap with the previous record by CID.
@@ -28,7 +28,7 @@ class Data(base.DataModelBase):
 
 class DataDict(t.TypedDict):
     collection: string_formats.Nsid  #: The NSID of the record collection.
-    repo: string_formats.Handle  #: The handle or DID of the repo (aka, current account).
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo (aka, current account).
     rkey: str  #: The Record Key.
     swap_commit: te.NotRequired[t.Optional[string_formats.Cid]]  #: Compare and swap with the previous commit by CID.
     swap_record: te.NotRequired[t.Optional[string_formats.Cid]]  #: Compare and swap with the previous record by CID.

--- a/packages/atproto_client/models/com/atproto/repo/describe_repo.py
+++ b/packages/atproto_client/models/com/atproto/repo/describe_repo.py
@@ -17,11 +17,11 @@ from atproto_client.models import base
 class Params(base.ParamsModelBase):
     """Parameters model for :obj:`com.atproto.repo.describeRepo`."""
 
-    repo: string_formats.Handle  #: The handle or DID of the repo.
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo.
 
 
 class ParamsDict(t.TypedDict):
-    repo: string_formats.Handle  #: The handle or DID of the repo.
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo.
 
 
 class Response(base.ResponseModelBase):

--- a/packages/atproto_client/models/com/atproto/repo/get_record.py
+++ b/packages/atproto_client/models/com/atproto/repo/get_record.py
@@ -20,7 +20,7 @@ class Params(base.ParamsModelBase):
     """Parameters model for :obj:`com.atproto.repo.getRecord`."""
 
     collection: string_formats.Nsid  #: The NSID of the record collection.
-    repo: string_formats.Handle  #: The handle or DID of the repo.
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo.
     rkey: str  #: The Record Key.
     cid: t.Optional[string_formats.Cid] = (
         None  #: The CID of the version of the record. If not specified, then return the most recent version.
@@ -29,7 +29,7 @@ class Params(base.ParamsModelBase):
 
 class ParamsDict(t.TypedDict):
     collection: string_formats.Nsid  #: The NSID of the record collection.
-    repo: string_formats.Handle  #: The handle or DID of the repo.
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo.
     rkey: str  #: The Record Key.
     cid: te.NotRequired[
         t.Optional[string_formats.Cid]

--- a/packages/atproto_client/models/com/atproto/repo/list_records.py
+++ b/packages/atproto_client/models/com/atproto/repo/list_records.py
@@ -22,7 +22,7 @@ class Params(base.ParamsModelBase):
     """Parameters model for :obj:`com.atproto.repo.listRecords`."""
 
     collection: string_formats.Nsid  #: The NSID of the record type.
-    repo: string_formats.Handle  #: The handle or DID of the repo.
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo.
     cursor: t.Optional[str] = None  #: Cursor.
     limit: t.Optional[int] = Field(default=50, ge=1, le=100)  #: The number of records to return.
     reverse: t.Optional[bool] = None  #: Flag to reverse the order of the returned records.
@@ -32,7 +32,7 @@ class Params(base.ParamsModelBase):
 
 class ParamsDict(t.TypedDict):
     collection: string_formats.Nsid  #: The NSID of the record type.
-    repo: string_formats.Handle  #: The handle or DID of the repo.
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo.
     cursor: te.NotRequired[t.Optional[str]]  #: Cursor.
     limit: te.NotRequired[t.Optional[int]]  #: The number of records to return.
     reverse: te.NotRequired[t.Optional[bool]]  #: Flag to reverse the order of the returned records.

--- a/packages/atproto_client/models/com/atproto/repo/put_record.py
+++ b/packages/atproto_client/models/com/atproto/repo/put_record.py
@@ -23,7 +23,7 @@ class Data(base.DataModelBase):
 
     collection: string_formats.Nsid  #: The NSID of the record collection.
     record: 'UnknownInputType'  #: The record to write.
-    repo: string_formats.Handle  #: The handle or DID of the repo (aka, current account).
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo (aka, current account).
     rkey: str = Field(max_length=512)  #: The Record Key.
     swap_commit: t.Optional[string_formats.Cid] = None  #: Compare and swap with the previous commit by CID.
     swap_record: t.Optional[string_formats.Cid] = (
@@ -37,7 +37,7 @@ class Data(base.DataModelBase):
 class DataDict(t.TypedDict):
     collection: string_formats.Nsid  #: The NSID of the record collection.
     record: 'UnknownInputType'  #: The record to write.
-    repo: string_formats.Handle  #: The handle or DID of the repo (aka, current account).
+    repo: string_formats.AtIdentifier  #: The handle or DID of the repo (aka, current account).
     rkey: str  #: The Record Key.
     swap_commit: te.NotRequired[t.Optional[string_formats.Cid]]  #: Compare and swap with the previous commit by CID.
     swap_record: te.NotRequired[

--- a/packages/atproto_client/models/string_formats.py
+++ b/packages/atproto_client/models/string_formats.py
@@ -1,4 +1,4 @@
-"""AT Proto string format validation."""
+"""AT Protocol string format validation."""
 
 import re
 from datetime import datetime
@@ -83,7 +83,7 @@ def only_validate_if_strict(validate_fn: Callable[..., str]) -> Callable[..., st
 
 @only_validate_if_strict
 def validate_handle(v: str, _: ValidationInfo) -> str:
-    """Validate an AT Protocol handle.
+    """Validate an AT Protocol Handle Identifier.
 
     A handle must be a valid domain name with:
 
@@ -121,7 +121,7 @@ def validate_handle(v: str, _: ValidationInfo) -> str:
 
 @only_validate_if_strict
 def validate_did(v: str, _: ValidationInfo) -> str:
-    """Validate an AT Protocol DID.
+    """Validate a Decentralized Identifiers (DID).
 
     A DID must follow the pattern:
 
@@ -232,7 +232,7 @@ def validate_language(v: str, _: ValidationInfo) -> str:
 
 @only_validate_if_strict
 def validate_record_key(v: str, _: ValidationInfo) -> str:
-    """Validate an AT Protocol record key.
+    """Validate an AT Protocol Record Key (rkey).
 
     A record key must:
 
@@ -241,7 +241,6 @@ def validate_record_key(v: str, _: ValidationInfo) -> str:
     - Contain only alphanumeric chars, dots, underscores, colons, tildes, or hyphens
 
     - Not be "." or ".."
-
 
     Args:
         v: The record key to validate (e.g. 3jxtb5w2hkt2m)
@@ -269,7 +268,8 @@ def validate_cid(v: str, _: ValidationInfo) -> str:
 
     - Alphanumeric characters and plus signs only
 
-    :param v: The CID to validate (e.g. bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi)
+    Args:
+        v: The CID to validate (e.g. bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi)
 
     Returns:
         The validated CID
@@ -298,7 +298,8 @@ def validate_at_uri(v: str, _: ValidationInfo) -> str:
 
     - No query parameters or fragments
 
-    :param v: The AT-URI to validate (e.g. at://alice.bsky.social/app.bsky.feed.post/3jxtb5w2hkt2m)
+    Args:
+        v: The AT-URI to validate (e.g. at://alice.bsky.social/app.bsky.feed.post/3jxtb5w2hkt2m)
 
     Returns:
         The validated AT-URI
@@ -375,7 +376,7 @@ def validate_datetime(v: str, _: ValidationInfo) -> str:
 
 @only_validate_if_strict
 def validate_tid(v: str, _: ValidationInfo) -> str:
-    """Validate an AT Protocol TID (Temporal ID).
+    """Validate an AT Protocol TID (Timestamp Identifiers).
 
     Must be:
 

--- a/packages/atproto_client/models/string_formats.py
+++ b/packages/atproto_client/models/string_formats.py
@@ -5,8 +5,6 @@
 - https://atproto.com/specs/lexicon
 
 - https://github.com/bluesky-social/atproto/tree/main/interop-test-files/syntax
-
-see https://github.com/MarshalX/atproto/pull/406 for more details.
 """
 
 import re

--- a/packages/atproto_client/models/string_formats.py
+++ b/packages/atproto_client/models/string_formats.py
@@ -64,7 +64,8 @@ class _NamedValidator:
         return self.validate_fn(v, info)
 
     def __str__(self) -> str:
-        return f'Validated by: {self.validate_fn.__name__} (only when `strict_string_format=True`)'
+        func_str = f':func:`string_formats.{self.validate_fn.__name__}`'
+        return f'Validated by: {func_str} (only when `strict_string_format=True`)'
 
 
 def only_validate_if_strict(validate_fn: Callable[..., str]) -> Callable[..., str]:

--- a/packages/atproto_client/models/string_formats.py
+++ b/packages/atproto_client/models/string_formats.py
@@ -1,3 +1,14 @@
+"""AT Proto string format validation.
+
+*Note*: These formats are a working empirical understanding of the following resources:
+
+- https://atproto.com/specs/lexicon
+
+- https://github.com/bluesky-social/atproto/tree/main/interop-test-files/syntax
+
+see https://github.com/MarshalX/atproto/pull/406 for more details.
+"""
+
 import re
 from datetime import datetime
 from typing import Callable, Mapping, Set, Union, cast

--- a/packages/atproto_client/models/string_formats.py
+++ b/packages/atproto_client/models/string_formats.py
@@ -65,10 +65,11 @@ AT_URI_RE = re.compile(
 def only_validate_if_strict(validate_fn: Callable[..., str]) -> Callable[..., str]:
     """Skip pydantic validation if not opting into strict validation via context.
 
-    :param validate_fn: The validation function to conditionally apply
-    :type validate_fn: Callable[..., str]
-    :return: A wrapped validation function that only validates in strict mode
-    :rtype: Callable[..., str]
+    Args:
+        validate_fn: The validation function to conditionally apply
+
+    Returns:
+        A wrapped validation function that only validates in strict mode
     """
 
     def wrapper(v: str, info: ValidationInfo) -> str:
@@ -100,11 +101,14 @@ def validate_handle(v: str) -> str:
 
     - Last segment cannot start with a digit
 
-    :param v: The handle to validate (e.g. alice.bsky.social)
-    :type v: str
-    :return: The validated handle
-    :rtype: str
-    :raises ValueError: If handle format is invalid
+    Args:
+        v: The handle to validate (e.g. alice.bsky.social)
+
+    Returns:
+        The validated handle
+
+    Raises:
+        ValueError: If handle format is invalid
     """
     # Check ASCII first
     if not v.isascii():
@@ -137,11 +141,14 @@ def validate_did(v: str) -> str:
 
     - Valid percent-encoding if used
 
-    :param v: The DID to validate (e.g. did:plc:z72i7hdynmk6r22z27h6tvur)
-    :type v: str
-    :return: The validated DID
-    :rtype: str
-    :raises ValueError: If DID format is invalid
+    Args:
+        v: The DID to validate (e.g. did:plc:z72i7hdynmk6r22z27h6tvur)
+
+    Returns:
+        The validated DID
+
+    Raises:
+        ValueError: If DID format is invalid
     """
     # Check for invalid characters
     if any(c in v for c in '/?#[]@'):
@@ -181,11 +188,14 @@ def validate_nsid(v: str) -> str:
 
     - Max 63 chars per segment
 
-    :param v: The NSID to validate (e.g. app.bsky.feed.post)
-    :type v: str
-    :return: The validated NSID
-    :rtype: str
-    :raises ValueError: If NSID format is invalid
+    Args:
+        v: The NSID to validate (e.g. app.bsky.feed.post)
+
+    Returns:
+        The validated NSID
+
+    Raises:
+        ValueError: If NSID format is invalid
     """
     if (
         not atproto_core_validate_nsid(v, soft_fail=True)
@@ -210,11 +220,14 @@ def validate_language(v: str) -> str:
 
     - Optional subtag with alphanumeric chars and hyphens
 
-    :param v: The language code to validate (e.g. en or en-US)
-    :type v: str
-    :return: The validated language code
-    :rtype: str
-    :raises ValueError: If language code format is invalid
+    Args:
+        v: The language code to validate (e.g. en or en-US)
+
+    Returns:
+        The validated language code
+
+    Raises:
+        ValueError: If language code format is invalid
     """
     if not LANG_RE.match(v):
         raise ValueError('Invalid language code: must be ISO language code (e.g. en or en-US)')
@@ -233,11 +246,15 @@ def validate_record_key(v: str) -> str:
 
     - Not be "." or ".."
 
-    :param v: The record key to validate (e.g. 3jxtb5w2hkt2m)
-    :type v: str
-    :return: The validated record key
-    :rtype: str
-    :raises ValueError: If record key format is invalid
+
+    Args:
+        v: The record key to validate (e.g. 3jxtb5w2hkt2m)
+
+    Returns:
+        The validated record key
+
+    Raises:
+        ValueError: If record key format is invalid
     """
     if v in INVALID_RECORD_KEYS or not RKEY_RE.match(v):
         raise ValueError(
@@ -257,10 +274,12 @@ def validate_cid(v: str) -> str:
     - Alphanumeric characters and plus signs only
 
     :param v: The CID to validate (e.g. bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi)
-    :type v: str
-    :return: The validated CID
-    :rtype: str
-    :raises ValueError: If CID format is invalid
+
+    Returns:
+        The validated CID
+
+    Raises:
+        ValueError: If CID format is invalid
     """
     if not CID_RE.match(v):
         raise ValueError('Invalid CID: must be a valid Content Identifier with minimum length 8')
@@ -284,10 +303,12 @@ def validate_at_uri(v: str) -> str:
     - No query parameters or fragments
 
     :param v: The AT-URI to validate (e.g. at://alice.bsky.social/app.bsky.feed.post/3jxtb5w2hkt2m)
-    :type v: str
-    :return: The validated AT-URI
-    :rtype: str
-    :raises ValueError: If AT-URI format is invalid
+
+    Returns:
+        The validated AT-URI
+
+    Raises:
+        ValueError: If AT-URI format is invalid
     """
     if len(v) >= MAX_AT_URI_LENGTH:
         raise ValueError(f'Invalid AT-URI: must be under {MAX_AT_URI_LENGTH} chars')
@@ -316,11 +337,14 @@ def validate_datetime(v: str) -> str:
 
     - No whitespace allowed
 
-    :param v: The datetime string to validate (e.g. 2024-11-24T06:02:00Z)
-    :type v: str
-    :return: The validated datetime string
-    :rtype: str
-    :raises ValueError: If datetime format is invalid
+    Args:
+        v: The datetime string to validate (e.g. 2024-11-24T06:02:00Z)
+
+    Returns:
+        The validated datetime string
+
+    Raises:
+        ValueError: If datetime format is invalid
     """
     # Must contain uppercase T and Z if used
     if v != v.strip():
@@ -365,11 +389,14 @@ def validate_tid(v: str) -> str:
 
     - First byte's high bit (0x40) must be 0
 
-    :param v: The TID to validate (e.g. 3jxtb5w2hkt2m)
-    :type v: str
-    :return: The validated TID
-    :rtype: str
-    :raises ValueError: If TID format is invalid
+    Args:
+        v: The TID to validate (e.g. 3jxtb5w2hkt2m)
+
+    Returns:
+        The validated TID
+
+    Raises:
+        ValueError: If TID format is invalid
     """
     if not TID_RE.match(v) or (ord(v[0]) & 0x40):
         raise ValueError(f'Invalid TID: must be exactly {TID_LENGTH} lowercase letters/numbers')
@@ -392,11 +419,14 @@ def validate_uri(v: str) -> str:
 
     - Must follow RFC-3986 format
 
-    :param v: The URI to validate (e.g. https://example.com/path)
-    :type v: str
-    :return: The validated URI
-    :rtype: str
-    :raises ValueError: If URI format is invalid
+    Args:
+        v: The URI to validate (e.g. https://example.com/path)
+
+    Returns:
+        The validated URI
+
+    Raises:
+        ValueError: If URI format is invalid
     """
     if len(v) >= MAX_URI_LENGTH or ' ' in v:
         raise ValueError(f'Invalid URI: must be under {MAX_URI_LENGTH} chars and not contain spaces')

--- a/packages/atproto_client/models/string_formats.py
+++ b/packages/atproto_client/models/string_formats.py
@@ -54,6 +54,19 @@ AT_URI_RE = re.compile(
 )
 
 
+class _NamedValidator:
+    """Decorator to add a __str__ attribute to a validation function."""
+
+    def __init__(self, validate_fn: Callable[..., str]) -> None:
+        self.validate_fn = validate_fn
+
+    def __call__(self, v: str, info: ValidationInfo) -> str:
+        return self.validate_fn(v, info)
+
+    def __str__(self) -> str:
+        return f'Validated by: {self.validate_fn.__name__} (only when `strict_string_format=True`)'
+
+
 def only_validate_if_strict(validate_fn: Callable[..., str]) -> Callable[..., str]:
     """Skip pydantic validation if not opting into strict validation via context."""
 
@@ -422,16 +435,16 @@ def validate_uri(v: str, _: ValidationInfo) -> str:
     return v
 
 
-Handle = Annotated[str, BeforeValidator(validate_handle)]
-Did = Annotated[str, BeforeValidator(validate_did)]
-Nsid = Annotated[str, BeforeValidator(validate_nsid)]
-Language = Annotated[str, BeforeValidator(validate_language)]
-RecordKey = Annotated[str, BeforeValidator(validate_record_key)]
-Cid = Annotated[str, BeforeValidator(validate_cid)]
-AtUri = Annotated[str, BeforeValidator(validate_at_uri)]
-DateTime = Annotated[str, BeforeValidator(validate_datetime)]  # see pydantic-extra-types #239
-Tid = Annotated[str, BeforeValidator(validate_tid)]
-Uri = Annotated[str, BeforeValidator(validate_uri)]
+Handle = Annotated[str, BeforeValidator(_NamedValidator(validate_handle))]
+Did = Annotated[str, BeforeValidator(_NamedValidator(validate_did))]
+Nsid = Annotated[str, BeforeValidator(_NamedValidator(validate_nsid))]
+Language = Annotated[str, BeforeValidator(_NamedValidator(validate_language))]
+RecordKey = Annotated[str, BeforeValidator(_NamedValidator(validate_record_key))]
+Cid = Annotated[str, BeforeValidator(_NamedValidator(validate_cid))]
+AtUri = Annotated[str, BeforeValidator(_NamedValidator(validate_at_uri))]
+DateTime = Annotated[str, BeforeValidator(_NamedValidator(validate_datetime))]  # see pydantic-extra-types #239
+Tid = Annotated[str, BeforeValidator(_NamedValidator(validate_tid))]
+Uri = Annotated[str, BeforeValidator(_NamedValidator(validate_uri))]
 
 # Any valid ATProto string format
 AtProtoString = Annotated[

--- a/packages/atproto_client/models/string_formats.py
+++ b/packages/atproto_client/models/string_formats.py
@@ -448,6 +448,8 @@ DateTime = Annotated[str, BeforeValidator(_NamedValidator(validate_datetime))]  
 Tid = Annotated[str, BeforeValidator(_NamedValidator(validate_tid))]
 Uri = Annotated[str, BeforeValidator(_NamedValidator(validate_uri))]
 
+AtIdentifier = Union[Handle, Did]
+
 # Any valid ATProto string format
 AtProtoString = Annotated[
     Union[Handle, Did, Nsid, AtUri, Cid, DateTime, Tid, RecordKey, Uri, Language],

--- a/packages/atproto_codegen/models/generator.py
+++ b/packages/atproto_codegen/models/generator.py
@@ -167,7 +167,7 @@ def _get_str_typehint(nsid: NSID, field_type_def: models.LexString, *, optional:
     if field_type_def.format:
         # Map format types to our string_formats types
         format_map = {
-            'at-identifier': 'string_formats.Handle',
+            'at-identifier': 'string_formats.AtIdentifier',
             'at-uri': 'string_formats.AtUri',
             'cid': 'string_formats.Cid',
             'datetime': 'string_formats.DateTime',


### PR DESCRIPTION
closes https://github.com/MarshalX/atproto/issues/478

this PR adds:
- [docstrings](https://atproto--491.org.readthedocs.build/en/491/atproto/atproto_client.models.string_formats.html) to all validator functions
- a new docs [page, `string_formats.md`](https://atproto--491.org.readthedocs.build/en/491/atproto_client/string_formats.html)

- improved rendering of string format contstraints, as [discussed below](https://github.com/MarshalX/atproto/pull/491#issuecomment-2544734404)
