### PR TITLE
Simplify a way to configure HTTPX client (timeouts, SSL, retry policies, etc.)

### DIFF
--- a/docs/source/atproto_client/auth.md
+++ b/docs/source/atproto_client/auth.md
@@ -12,7 +12,7 @@ Depending on account status and password, the access token permissions are varie
 For example, access tokens created with app-password have limited permissions to create new app-passwords, change email, etc.
 
 The session is created via the [login](#atproto_client.client.client.Client.login) method. 
-Under the hood, the SDK uses [create_session](#atproto_client.namespaces.sync_ns.ServerNamespace.create_session) method.
+Under the hood, the SDK uses [create_session](#atproto_client.namespaces.sync_ns.ComAtprotoServerNamespace.create_session) method.
 
 ```python
 from atproto_client import Client
@@ -50,7 +50,7 @@ The refresh token is used to get a new access token when the old one expires.
 
 The access token is valid for ~2 hours, and the refresh token is valid for ~2 months.
 
-SDK will automatically refresh the access token when it expires using [refresh_session](#atproto_client.namespaces.sync_ns.ServerNamespace.refresh_session) method.
+SDK will automatically refresh the access token when it expires using [refresh_session](#atproto_client.namespaces.sync_ns.ComAtprotoServerNamespace.refresh_session) method.
 
 You are always able to export the current session to persistent storage and import it later.
 To export the session, use the [export_session_string](#atproto_client.client.client.Client.export_session_string) method.

--- a/docs/source/atproto_client/index.rst
+++ b/docs/source/atproto_client/index.rst
@@ -16,5 +16,6 @@ Submodules
    namespace
    models
    auth
+   timeouts
    string_formats
    utils/index

--- a/docs/source/atproto_client/timeouts.md
+++ b/docs/source/atproto_client/timeouts.md
@@ -19,7 +19,7 @@ request = Request(timeout=None)  # Disable all timeouts by default.
 
 client = Client(request=request)
 
-# ... perform requests
+# ... invoke methods
 ```
 
 :::{tip}
@@ -38,5 +38,5 @@ async_request = AsyncRequest(timeout=None)  # Disable all timeouts by default.
 
 async_client = AsyncClient(request=async_request)
 
-# ... perform requests
+# ... invoke methods
 ```

--- a/docs/source/atproto_client/timeouts.md
+++ b/docs/source/atproto_client/timeouts.md
@@ -1,0 +1,42 @@
+## Timeouts
+
+SDK uses `HTTPX` under the hood. Which enforce timeouts everywhere by default. The default timeout is **5 seconds**, but you can set it to whatever you want. You can set the timeout for all requests by using custom [Request](#atproto_client.request.Request) instance.
+
+The [InvokeTimeoutError](#atproto_client.exceptions.InvokeTimeoutError) will be raised if the request takes longer than the timeout.
+
+The most common case where you want to increase the timeout is when you are uploading blobs (videos, images, large files).
+
+Learn more about fine-tuning the timeout in the [HTTPX documentation](https://www.python-httpx.org/advanced/timeouts/).
+
+```python
+from atproto import Client, Request
+from httpx import Timeout
+
+
+request = Request()  # Use a default 5s timeout everywhere.
+request = Request(timeout=Timeout(timeout=10.0))  # Use a default 10s timeout everywhere.
+request = Request(timeout=None)  # Disable all timeouts by default.
+
+client = Client(request=request)
+
+# ... perform requests
+```
+
+:::{tip}
+Using custom `Request` instance is the best way to configure `HTTPX` client. You can use it for other options as well, like `proxies`, `transport` for retrying policies, etc.
+:::
+
+For async interfaces, you can set the timeout in the same way. The [AsyncRequest](#atproto_client.request.AsyncRequest) instance is passed to the `AsyncClient` constructor.
+
+```python
+from atproto import AsyncClient, AsyncRequest
+from httpx import Timeout
+
+async_request = AsyncRequest()  # Use a default 5s timeout everywhere.
+async_request = AsyncRequest(timeout=Timeout(timeout=10.0))  # Use a default 10s timeout everywhere.
+async_request = AsyncRequest(timeout=None)  # Disable all timeouts by default.
+
+async_client = AsyncClient(request=async_request)
+
+# ... perform requests
+```

--- a/packages/atproto/__init__.py
+++ b/packages/atproto/__init__.py
@@ -1,5 +1,6 @@
 from atproto_client import AsyncClient, Client, Session, SessionEvent, models
 from atproto_client import utils as client_utils
+from atproto_client.request import AsyncRequest, Request
 from atproto_core.car import CAR
 from atproto_core.cid import CID, CIDType
 from atproto_core.did_doc import DidDocument
@@ -38,6 +39,8 @@ __all__ = [
     'Session',
     'client_utils',
     'models',
+    'Request',
+    'AsyncRequest',
     # core
     'CAR',
     'CID',

--- a/packages/atproto_client/request.py
+++ b/packages/atproto_client/request.py
@@ -155,11 +155,15 @@ class RequestBase:
 
 
 class Request(RequestBase):
-    """Class for handling requests errors and working with httpx."""
+    """Class for handling requests errors and working with httpx.
 
-    def __init__(self) -> None:
+    Args:
+        **kwargs: Additional parameters for httpx.Client.
+    """
+
+    def __init__(self, **kwargs: t.Any) -> None:
         super().__init__()
-        self._client = httpx.Client(follow_redirects=True)
+        self._client = httpx.Client(follow_redirects=True, **kwargs)
 
     def _send_request(self, method: str, url: str, **kwargs: t.Any) -> httpx.Response:
         headers = self.get_headers(kwargs.pop('headers', None))
@@ -182,11 +186,15 @@ class Request(RequestBase):
 
 
 class AsyncRequest(RequestBase):
-    """Class for handling requests errors and working with httpx."""
+    """Class for handling requests errors and working with httpx.
 
-    def __init__(self) -> None:
+    Args:
+        **kwargs: Additional parameters for httpx.AsyncClient.
+    """
+
+    def __init__(self, **kwargs: t.Any) -> None:
         super().__init__()
-        self._client = httpx.AsyncClient(follow_redirects=True)
+        self._client = httpx.AsyncClient(follow_redirects=True, **kwargs)
 
     async def _send_request(self, method: str, url: str, **kwargs: t.Any) -> httpx.Response:
         headers = self.get_headers(kwargs.pop('headers', None))


### PR DESCRIPTION
closes #501