### PR TITLE
ruff rules PERF

### DIFF
--- a/examples/advanced_usage/notifications_callback.py
+++ b/examples/advanced_usage/notifications_callback.py
@@ -29,10 +29,9 @@ async def main() -> None:
             response = await async_client.app.bsky.notification.list_notifications()
 
             # create a task list to run callbacks concurrently
-            on_notification_tasks = []
-            for notification in response.notifications:
-                if not notification.is_read:
-                    on_notification_tasks.append(on_notification(notification))
+            on_notification_tasks = [
+                on_notification(notification) for notification in response.notifications if not notification.is_read
+            ]
 
             # run callback on each notification
             await asyncio.gather(*on_notification_tasks)

--- a/packages/atproto_client/client/session.py
+++ b/packages/atproto_client/client/session.py
@@ -74,9 +74,10 @@ class SessionDispatcher:
         assert _session_exists(self._session)
         session_copy = self._session.copy()  # Avoid modifying the original session
 
-        coroutines: t.List[t.Coroutine[t.Any, t.Any, None]] = []
-        for on_session_change_async_callback in self._on_session_change_async_callbacks:
-            coroutines.append(on_session_change_async_callback(event, session_copy))
+        coroutines: t.List[t.Coroutine[t.Any, t.Any, None]] = [
+            on_session_change_async_callback(event, session_copy)
+            for on_session_change_async_callback in self._on_session_change_async_callbacks
+        ]
 
         await asyncio.gather(*coroutines)
 

--- a/packages/atproto_codegen/models/generator.py
+++ b/packages/atproto_codegen/models/generator.py
@@ -689,15 +689,14 @@ def _generate_def_models(lex_db: builder.BuiltDefModels) -> None:
 
 
 def _generate_record_sugar_models(nsid: NSID) -> str:
-    lines = []
-    for model in [
-        RECORD_GET_RESPONSE_MODEL_TEMPLATE,
-        RECORD_LIST_RESPONSE_MODEL_TEMPLATE,
-        RECORD_CREATE_RESPONSE_MODEL_TEMPLATE,
-    ]:
-        lines.append(model.format(record_import=get_import_path(nsid)))
-
-    return join_code(lines)
+    return join_code(
+        model.format(record_import=get_import_path(nsid))
+        for model in (
+            RECORD_GET_RESPONSE_MODEL_TEMPLATE,
+            RECORD_LIST_RESPONSE_MODEL_TEMPLATE,
+            RECORD_CREATE_RESPONSE_MODEL_TEMPLATE,
+        )
+    )
 
 
 def _generate_record_models(lex_db: builder.BuiltRecordModels) -> None:

--- a/packages/atproto_codegen/namespaces/builder.py
+++ b/packages/atproto_codegen/namespaces/builder.py
@@ -17,13 +17,11 @@ _VALID_LEX_DEF_TYPES = {LexDefinitionType.QUERY, LexDefinitionType.PROCEDURE, Le
 
 
 def _filter_namespace_valid_definitions(definitions: t.Dict[str, LexDefinition]) -> t.Dict[str, LexDefinition]:
-    result = {}
-
-    for def_name, def_content in definitions.items():
-        if def_content.type in _VALID_LEX_DEF_TYPES:
-            result[def_name] = def_content
-
-    return result
+    return {
+        def_name: def_content
+        for def_name, def_content in definitions.items()
+        if def_content.type is LexDefinitionType.NAMESPACE
+    }
 
 
 def get_definition_by_name(name: str, defs: t.Dict[str, LexDefinition]) -> LexDefinition:

--- a/packages/atproto_codegen/namespaces/generator.py
+++ b/packages/atproto_codegen/namespaces/generator.py
@@ -97,8 +97,9 @@ def _get_init_method(sub_items: t.List[str], *, sync: bool, parent_nodes: t.List
     if for_record:
         get_name = get_record_name
 
-    for sub_item in sub_items:
-        lines.append(f'{_(2)}self.{sub_item} = {get_name([*parent_nodes, sub_item])}(self._client)')
+    lines.extend(
+        f'{_(2)}self.{sub_item} = {get_name([*parent_nodes, sub_item])}(self._client)' for sub_item in sub_items
+    )
 
     return join_code(lines)
 
@@ -333,19 +334,15 @@ def _get_namespace_methods_block(methods_info: t.List[MethodInfo], sync: bool) -
 def _get_record_methods_block(record_info: RecordInfo, sync: bool) -> str:
     d, c = get_sync_async_keywords(sync=sync)
 
-    lines = []
-
-    for method_template in [
-        RECORD_GET_METHOD_TEMPLATE,
-        RECORD_LIST_METHOD_TEMPLATE,
-        RECORD_CREATE_METHOD_TEMPLATE,
-        RECORD_DELETE_METHOD_TEMPLATE,
-    ]:
-        lines.append(
-            method_template.format(
-                record_import=get_import_path(record_info.nsid), collection=record_info.nsid, d=d, c=c
-            )
+    lines = [
+        method_template.format(record_import=get_import_path(record_info.nsid), collection=record_info.nsid, d=d, c=c)
+        for method_template in (
+            RECORD_GET_METHOD_TEMPLATE,
+            RECORD_LIST_METHOD_TEMPLATE,
+            RECORD_CREATE_METHOD_TEMPLATE,
+            RECORD_DELETE_METHOD_TEMPLATE,
         )
+    ]
 
     return join_code(lines)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ extend-select = [
     "INP",
     "ISC",
     "NPY",
+    "PERF",
     "PGH",
     "PIE",
     "RET",


### PR DESCRIPTION
% `ruff check --select=PERF --output-format=concise`
```
examples/advanced_usage/notifications_callback.py:35:21: PERF401 Use a list comprehension to create a transformed list
packages/atproto_client/client/session.py:79:13: PERF401 Use a list comprehension to create a transformed list
packages/atproto_codegen/models/generator.py:698:9: PERF401 Use a list comprehension to create a transformed list
packages/atproto_codegen/namespaces/builder.py:24:13: PERF403 Use a dictionary comprehension instead of a for-loop
packages/atproto_codegen/namespaces/generator.py:101:9: PERF401 Use `list.extend` to create a transformed list
packages/atproto_codegen/namespaces/generator.py:344:9: PERF401 Use a list comprehension to create a transformed list
Found 6 errors.
```