### PR TITLE
Add OAuth 2.1 implementation for ATProto SDK

### DIFF
--- a/docs/source/atproto/atproto_oauth.client.rst
+++ b/docs/source/atproto/atproto_oauth.client.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.client
+=====================
+
+.. automodule:: atproto_oauth.client
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.dpop.rst
+++ b/docs/source/atproto/atproto_oauth.dpop.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.dpop
+===================
+
+.. automodule:: atproto_oauth.dpop
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.exceptions.rst
+++ b/docs/source/atproto/atproto_oauth.exceptions.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.exceptions
+=========================
+
+.. automodule:: atproto_oauth.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.metadata.rst
+++ b/docs/source/atproto/atproto_oauth.metadata.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.metadata
+=======================
+
+.. automodule:: atproto_oauth.metadata
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.models.rst
+++ b/docs/source/atproto/atproto_oauth.models.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.models
+=====================
+
+.. automodule:: atproto_oauth.models
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.pkce.rst
+++ b/docs/source/atproto/atproto_oauth.pkce.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.pkce
+===================
+
+.. automodule:: atproto_oauth.pkce
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.rst
+++ b/docs/source/atproto/atproto_oauth.rst
@@ -1,0 +1,29 @@
+atproto\_oauth
+==============
+
+.. automodule:: atproto_oauth
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   atproto_oauth.stores
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   atproto_oauth.client
+   atproto_oauth.dpop
+   atproto_oauth.exceptions
+   atproto_oauth.metadata
+   atproto_oauth.models
+   atproto_oauth.pkce
+   atproto_oauth.security

--- a/docs/source/atproto/atproto_oauth.rst
+++ b/docs/source/atproto/atproto_oauth.rst
@@ -5,7 +5,6 @@ atproto\_oauth
    :members:
    :undoc-members:
    :show-inheritance:
-   :noindex:
 
 Subpackages
 -----------

--- a/docs/source/atproto/atproto_oauth.rst
+++ b/docs/source/atproto/atproto_oauth.rst
@@ -5,6 +5,7 @@ atproto\_oauth
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Subpackages
 -----------
@@ -12,6 +13,7 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   atproto_oauth.scopes
    atproto_oauth.stores
 
 Submodules

--- a/docs/source/atproto/atproto_oauth.scopes.exceptions.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.exceptions.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.scopes.exceptions
+=================================
+
+.. automodule:: atproto_oauth.scopes.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.scopes.exceptions.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.exceptions.rst
@@ -1,5 +1,5 @@
 atproto\_oauth.scopes.exceptions
-=================================
+================================
 
 .. automodule:: atproto_oauth.scopes.exceptions
    :members:

--- a/docs/source/atproto/atproto_oauth.scopes.permissions.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.permissions.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.scopes.permissions
+==================================
+
+.. automodule:: atproto_oauth.scopes.permissions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.scopes.permissions.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.permissions.rst
@@ -1,5 +1,5 @@
 atproto\_oauth.scopes.permissions
-==================================
+=================================
 
 .. automodule:: atproto_oauth.scopes.permissions
    :members:

--- a/docs/source/atproto/atproto_oauth.scopes.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.rst
@@ -1,0 +1,20 @@
+atproto\_oauth.scopes
+=====================
+
+.. automodule:: atproto_oauth.scopes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :noindex:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   atproto_oauth.scopes.exceptions
+   atproto_oauth.scopes.permissions
+   atproto_oauth.scopes.scope_permissions
+   atproto_oauth.scopes.scopes_set
+   atproto_oauth.scopes.transition

--- a/docs/source/atproto/atproto_oauth.scopes.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.rst
@@ -5,7 +5,6 @@ atproto\_oauth.scopes
    :members:
    :undoc-members:
    :show-inheritance:
-   :noindex:
 
 Submodules
 ----------

--- a/docs/source/atproto/atproto_oauth.scopes.scope_permissions.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.scope_permissions.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.scopes.scope\_permissions
+=========================================
+
+.. automodule:: atproto_oauth.scopes.scope_permissions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.scopes.scope_permissions.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.scope_permissions.rst
@@ -1,5 +1,5 @@
 atproto\_oauth.scopes.scope\_permissions
-=========================================
+========================================
 
 .. automodule:: atproto_oauth.scopes.scope_permissions
    :members:

--- a/docs/source/atproto/atproto_oauth.scopes.scopes_set.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.scopes_set.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.scopes.scopes\_set
+==================================
+
+.. automodule:: atproto_oauth.scopes.scopes_set
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.scopes.scopes_set.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.scopes_set.rst
@@ -1,5 +1,5 @@
 atproto\_oauth.scopes.scopes\_set
-==================================
+=================================
 
 .. automodule:: atproto_oauth.scopes.scopes_set
    :members:

--- a/docs/source/atproto/atproto_oauth.scopes.transition.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.transition.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.scopes.transition
+=================================
+
+.. automodule:: atproto_oauth.scopes.transition
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.scopes.transition.rst
+++ b/docs/source/atproto/atproto_oauth.scopes.transition.rst
@@ -1,5 +1,5 @@
 atproto\_oauth.scopes.transition
-=================================
+================================
 
 .. automodule:: atproto_oauth.scopes.transition
    :members:

--- a/docs/source/atproto/atproto_oauth.security.rst
+++ b/docs/source/atproto/atproto_oauth.security.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.security
+=======================
+
+.. automodule:: atproto_oauth.security
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.stores.base.rst
+++ b/docs/source/atproto/atproto_oauth.stores.base.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.stores.base
+==========================
+
+.. automodule:: atproto_oauth.stores.base
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.stores.memory.rst
+++ b/docs/source/atproto/atproto_oauth.stores.memory.rst
@@ -1,0 +1,7 @@
+atproto\_oauth.stores.memory
+============================
+
+.. automodule:: atproto_oauth.stores.memory
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/atproto/atproto_oauth.stores.rst
+++ b/docs/source/atproto/atproto_oauth.stores.rst
@@ -1,0 +1,16 @@
+atproto\_oauth.stores
+=====================
+
+.. automodule:: atproto_oauth.stores
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   atproto_oauth.stores.base
+   atproto_oauth.stores.memory

--- a/docs/source/atproto/modules.rst
+++ b/docs/source/atproto/modules.rst
@@ -13,4 +13,5 @@ packages
    atproto_firehose
    atproto_identity
    atproto_lexicon
+   atproto_oauth
    atproto_server

--- a/docs/source/atproto_oauth/index.rst
+++ b/docs/source/atproto_oauth/index.rst
@@ -1,0 +1,124 @@
+OAuth (authentication)
+======================
+
+The AT Protocol uses `OAuth 2.1 <https://atproto.com/specs/oauth>`_ for user authentication. OAuth replaces the older App Password flow and is the recommended way to authenticate users in new applications.
+
+OAuth on AT Protocol uses several security mechanisms together: Pushed Authorization Requests (PAR), Proof Key for Code Exchange (PKCE), and Demonstrating Proof-of-Possession (DPoP). The ``atproto_oauth`` package handles all of these automatically.
+
+Quick start
+-----------
+
+1. Register your app by hosting a ``client-metadata.json`` file at a public URL. See the `client metadata spec <https://atproto.com/specs/oauth#clients>`_ for the required fields.
+
+2. Create an ``OAuthClient`` and start the authorization flow:
+
+..  code-block:: python
+
+    from atproto_oauth import OAuthClient
+    from atproto_oauth.stores.memory import MemoryStateStore, MemorySessionStore
+
+    client = OAuthClient(
+        client_id='https://myapp.example.com/client-metadata.json',
+        redirect_uri='https://myapp.example.com/callback',
+        scope='atproto transition:generic',
+        state_store=MemoryStateStore(),
+        session_store=MemorySessionStore(),
+    )
+
+    # Start authorization — returns a URL to redirect the user to
+    auth_url, state = await client.start_authorization('user.bsky.social')
+    # Redirect the user to auth_url...
+
+3. Handle the callback after the user authorizes your app:
+
+..  code-block:: python
+
+    # In your callback handler:
+    session = await client.handle_callback(
+        code=request.args['code'],
+        state=request.args['state'],
+        iss=request.args['iss'],
+    )
+    print(f'Authenticated as {session.did} ({session.handle})')
+
+4. Make authenticated requests to the user's PDS:
+
+..  code-block:: python
+
+    response = await client.make_authenticated_request(
+        session=session,
+        method='GET',
+        url=f'{session.pds_url}/xrpc/app.bsky.actor.getProfile',
+        params={'actor': session.did},
+    )
+
+Session management
+------------------
+
+Access tokens expire. The ``OAuthSession.expires_at`` field tells you when. Use ``refresh_session`` to get new tokens before the old ones expire:
+
+..  code-block:: python
+
+    from datetime import datetime, timezone
+
+    if session.expires_at and datetime.now(timezone.utc) >= session.expires_at:
+        session = await client.refresh_session(session)
+
+To revoke a session (log the user out):
+
+..  code-block:: python
+
+    await client.revoke_session(session)
+
+Stores
+------
+
+The ``state_store`` holds temporary state during the authorization flow. The ``session_store`` holds active sessions with tokens.
+
+The built-in ``MemoryStateStore`` and ``MemorySessionStore`` work for development but lose data on restart. For production, implement the ``StateStore`` and ``SessionStore`` abstract base classes with persistent storage (database, Redis, etc.):
+
+..  code-block:: python
+
+    from atproto_oauth.stores.base import StateStore, SessionStore
+
+    class MySessionStore(SessionStore):
+        async def save_session(self, session):
+            # save to database
+            ...
+
+        async def get_session(self, did):
+            # load from database
+            ...
+
+        async def delete_session(self, did):
+            # delete from database
+            ...
+
+Confidential clients
+--------------------
+
+Server-side applications can use confidential client authentication with ``private_key_jwt`` for stronger security. Provide your signing key when creating the client:
+
+..  code-block:: python
+
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    # Load or generate your client's signing key
+    client_secret_key = ec.generate_private_key(ec.SECP256R1())
+
+    client = OAuthClient(
+        client_id='https://myapp.example.com/client-metadata.json',
+        redirect_uri='https://myapp.example.com/callback',
+        scope='atproto transition:generic',
+        state_store=MemoryStateStore(),
+        session_store=MemorySessionStore(),
+        client_secret_key=client_secret_key,
+    )
+
+.. note::
+    Your ``client-metadata.json`` must declare ``token_endpoint_auth_method`` as ``private_key_jwt`` and include the corresponding public key in ``jwks`` when using confidential client authentication.
+
+.. automodule:: atproto_oauth
+   :members:
+   :undoc-members:
+   :inherited-members:

--- a/docs/source/atproto_oauth/index.rst
+++ b/docs/source/atproto_oauth/index.rst
@@ -97,7 +97,7 @@ The built-in ``MemoryStateStore`` and ``MemorySessionStore`` work for developmen
 Confidential clients
 --------------------
 
-Server-side applications can use confidential client authentication with ``private_key_jwt`` for stronger security. Provide your signing key when creating the client:
+Server-side applications can use confidential client authentication with ``private_key_jwt`` for stronger security. See the `AT Protocol OAuth spec on confidential clients <https://atproto.com/specs/oauth#confidential-clients>`_ for details. Provide your signing key when creating the client:
 
 ..  code-block:: python
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ Documentation
    atproto_core/index
    atproto_firehose/index
    atproto_identity/index
+   atproto_oauth/index
    atproto_crypto/index
    atproto_server/index
    atproto_lexicon/index

--- a/packages/atproto_oauth/README.md
+++ b/packages/atproto_oauth/README.md
@@ -1,0 +1,388 @@
+# atproto_oauth
+
+complete OAuth 2.1 implementation for the ATProto Python SDK, following the [ATProto OAuth specification](https://atproto.com/specs/oauth).
+
+## features
+
+✅ **full OAuth 2.1 compliance**
+- authorization code grant with PKCE (S256)
+- DPoP (Demonstrating Proof-of-Possession) with ES256
+- PAR (Pushed Authorization Requests)
+- automatic DPoP nonce rotation
+- client assertions for confidential clients
+
+✅ **ATProto-specific**
+- DID-based authentication
+- handle/DID resolution and verification
+- PDS endpoint discovery
+- authorization server discovery
+- works with Bluesky and custom PDS instances
+
+✅ **production-ready**
+- comprehensive error handling
+- SSRF protection and URL validation
+- async-first with sync support
+- pluggable state/session stores
+- fully typed with type hints
+- 12 unit tests, all passing
+
+## quick start
+
+### basic usage
+
+```python
+from atproto_oauth import OAuthClient
+from atproto_oauth.stores import MemorySessionStore, MemoryStateStore
+
+# create OAuth client
+client = OAuthClient(
+    client_id='http://localhost',  # or your HTTPS URL for production
+    redirect_uri='http://127.0.0.1:5000/callback',
+    scope='atproto',
+    state_store=MemoryStateStore(),
+    session_store=MemorySessionStore(),
+)
+
+# start authorization flow
+auth_url, state = await client.start_authorization('user.bsky.social')
+
+# user authorizes in browser, then...
+
+# handle callback
+session = await client.handle_callback(
+    code=authorization_code,
+    state=state,
+    iss=issuer_from_callback,
+)
+
+# make authenticated requests
+response = await client.make_authenticated_request(
+    session=session,
+    method='GET',
+    url=f'{session.pds_url}/xrpc/com.atproto.repo.describeRepo?repo={session.did}',
+)
+```
+
+### flask example
+
+see [examples/oauth_flask_demo](../../examples/oauth_flask_demo/) for complete working example.
+
+## installation
+
+```bash
+uv add atproto  # includes atproto_oauth
+```
+
+## core components
+
+### OAuthClient
+
+main client for OAuth operations:
+
+```python
+client = OAuthClient(
+    client_id='https://yourapp.com/client-metadata.json',
+    redirect_uri='https://yourapp.com/callback',
+    scope='atproto repo:app.bsky.feed.post',
+    state_store=your_state_store,
+    session_store=your_session_store,
+    client_secret_key=your_secret_key,  # optional, for confidential clients
+)
+```
+
+**methods:**
+- `start_authorization(handle_or_did)` - begin OAuth flow
+- `handle_callback(code, state, iss)` - complete OAuth flow
+- `refresh_session(session)` - refresh tokens
+- `revoke_session(session)` - revoke tokens
+- `make_authenticated_request(session, method, url)` - make DPoP-authenticated requests
+
+### stores
+
+pluggable storage for OAuth state and sessions:
+
+```python
+from atproto_oauth.stores import MemoryStateStore, MemorySessionStore
+
+# memory stores (development only)
+state_store = MemoryStateStore(state_ttl_seconds=600)
+session_store = MemorySessionStore()
+```
+
+**custom stores:**
+
+implement `StateStore` and `SessionStore` interfaces:
+
+```python
+from atproto_oauth.stores.base import StateStore, SessionStore
+
+class MyDatabaseStateStore(StateStore):
+    async def save_state(self, state: OAuthState) -> None:
+        # save to database
+        pass
+
+    async def get_state(self, state_key: str) -> Optional[OAuthState]:
+        # retrieve from database
+        pass
+
+    async def delete_state(self, state_key: str) -> None:
+        # delete from database
+        pass
+```
+
+### models
+
+```python
+from atproto_oauth.models import OAuthSession, OAuthState, AuthServerMetadata
+
+# OAuth session with tokens
+session: OAuthSession
+
+# access user info
+print(session.did, session.handle, session.pds_url)
+print(session.access_token, session.refresh_token)
+```
+
+### utilities
+
+```python
+from atproto_oauth.pkce import PKCEManager
+from atproto_oauth.dpop import DPoPManager
+from atproto_oauth.metadata import fetch_authserver_metadata_async
+
+# generate PKCE pair
+verifier, challenge = PKCEManager.generate_pair()
+
+# generate DPoP keypair
+dpop_key = DPoPManager.generate_keypair()
+
+# discover authorization server
+metadata = await fetch_authserver_metadata_async('https://bsky.social')
+```
+
+## architecture
+
+### authorization flow
+
+```
+1. user enters handle (e.g., user.bsky.social)
+2. resolve handle → DID → PDS endpoint → auth server
+3. generate PKCE verifier/challenge
+4. generate DPoP keypair
+5. send PAR (Pushed Authorization Request)
+6. redirect user to authorization server
+7. user authorizes
+8. callback with authorization code
+9. exchange code for tokens (with PKCE + DPoP)
+10. store OAuth session
+```
+
+### security features
+
+**PKCE (Proof Key for Code Exchange)**
+- prevents authorization code interception
+- S256 challenge method required
+
+**DPoP (Demonstrating Proof-of-Possession)**
+- binds tokens to client key
+- prevents token theft/replay
+- automatic nonce rotation
+
+**state parameter**
+- CSRF protection
+- cryptographically secure tokens
+- single-use, time-limited
+
+**URL validation**
+- SSRF protection
+- private IP blocking
+- HTTPS enforcement (except localhost)
+
+## comparison with nick's PR #589
+
+### what nick implemented ✅
+- DPoP support in Session class
+- static token handling
+- basic DPoP JWT generation
+
+### what this package adds 🆕
+- complete OAuth authorization flow
+- PKCE implementation
+- PAR (Pushed Authorization Requests)
+- state management with stores
+- token refresh with OAuth
+- client metadata support
+- authorization server discovery
+- comprehensive error handling
+- production-ready security
+
+## production deployment
+
+### 1. use persistent stores
+
+```python
+from your_app.stores import RedisStateStore, PostgreSQLSessionStore
+
+client = OAuthClient(
+    state_store=RedisStateStore(),
+    session_store=PostgreSQLSessionStore(),
+    ...
+)
+```
+
+### 2. deploy with HTTPS
+
+```python
+client = OAuthClient(
+    client_id='https://yourapp.com/oauth-client-metadata.json',
+    redirect_uri='https://yourapp.com/callback',
+    ...
+)
+```
+
+### 3. create client metadata
+
+serve at `https://yourapp.com/oauth-client-metadata.json`:
+
+```json
+{
+  "client_id": "https://yourapp.com/oauth-client-metadata.json",
+  "dpop_bound_access_tokens": true,
+  "application_type": "web",
+  "redirect_uris": ["https://yourapp.com/callback"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "scope": "atproto",
+  "token_endpoint_auth_method": "private_key_jwt",
+  "token_endpoint_auth_signing_alg": "ES256",
+  "jwks_uri": "https://yourapp.com/oauth/jwks.json",
+  "client_name": "Your App Name",
+  "client_uri": "https://yourapp.com"
+}
+```
+
+### 4. generate client secret (confidential clients)
+
+```python
+from atproto_oauth.dpop import DPoPManager
+
+# generate once, store securely (e.g., in secrets manager)
+client_secret_key = DPoPManager.generate_keypair()
+
+# use in OAuth client
+client = OAuthClient(
+    client_secret_key=client_secret_key,
+    ...
+)
+```
+
+### 5. implement token refresh
+
+```python
+# check if token is expired
+if session.expires_at and datetime.now(timezone.utc) > session.expires_at:
+    session = await client.refresh_session(session)
+```
+
+### 6. handle errors gracefully
+
+```python
+from atproto_oauth.exceptions import OAuthError, OAuthStateError, OAuthTokenError
+
+try:
+    session = await client.handle_callback(code, state, iss)
+except OAuthStateError as e:
+    # invalid/expired state - restart flow
+    pass
+except OAuthTokenError as e:
+    # token exchange failed - show error
+    pass
+except OAuthError as e:
+    # general OAuth error
+    pass
+```
+
+## testing
+
+run unit tests:
+
+```bash
+uv run pytest tests/test_oauth_pkce.py tests/test_oauth_dpop.py -v
+```
+
+all 12 tests pass:
+- ✅ PKCE verifier/challenge generation
+- ✅ DPoP keypair generation
+- ✅ DPoP proof JWT creation
+- ✅ DPoP nonce error detection
+- ✅ access token hash (ath) claim
+
+## troubleshooting
+
+### "Invalid or expired state parameter"
+**cause:** state expired (default 10 min) or already used
+**solution:** restart authorization flow
+
+### "DID mismatch in token"
+**cause:** user identity changed during authorization
+**solution:** retry with fresh authorization
+
+### "Unsupported authorization server"
+**cause:** auth server doesn't meet ATProto requirements
+**solution:** check server metadata compliance
+
+### "DPoP nonce error"
+**cause:** server requires fresh nonce (handled automatically)
+**solution:** library retries automatically
+
+### import errors
+**cause:** missing dependencies
+**solution:** `uv sync` to install all dependencies
+
+## development
+
+### run tests
+
+```bash
+uv run pytest tests/test_oauth*.py -v
+```
+
+### run flask demo
+
+```bash
+uv run python examples/oauth_flask_demo/app.py
+```
+
+### type checking
+
+```bash
+uv run mypy packages/atproto_oauth
+```
+
+## references
+
+- [ATProto OAuth Specification](https://atproto.com/specs/oauth)
+- [OAuth 2.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1)
+- [RFC 9449 - DPoP](https://datatracker.ietf.org/doc/html/rfc9449)
+- [RFC 7636 - PKCE](https://datatracker.ietf.org/doc/html/rfc7636)
+- [RFC 9126 - PAR](https://datatracker.ietf.org/doc/html/rfc9126)
+- [Bluesky OAuth Cookbook](https://github.com/bluesky-social/cookbook/tree/main/python-oauth-web-app)
+
+## license
+
+MIT
+
+## contributing
+
+contributions welcome! areas for improvement:
+
+- [ ] SQLite/PostgreSQL session stores
+- [ ] Redis state store
+- [ ] token automatic refresh
+- [ ] scope management helpers
+- [ ] more comprehensive tests
+- [ ] integration tests with real PDS
+- [ ] async/sync sync wrappers
+- [ ] documentation improvements
+
+see main [atproto repository](https://github.com/MarshalX/atproto) for contribution guidelines.

--- a/packages/atproto_oauth/__init__.py
+++ b/packages/atproto_oauth/__init__.py
@@ -1,0 +1,21 @@
+"""ATProto OAuth 2.1 implementation."""
+
+from atproto_oauth.client import OAuthClient, PromptType
+from atproto_oauth.exceptions import (
+    OAuthError,
+    OAuthStateError,
+    OAuthTokenError,
+    UnsupportedAuthServerError,
+)
+from atproto_oauth.models import OAuthSession, OAuthState
+
+__all__ = [
+    'OAuthClient',
+    'OAuthError',
+    'OAuthSession',
+    'OAuthState',
+    'OAuthStateError',
+    'OAuthTokenError',
+    'PromptType',
+    'UnsupportedAuthServerError',
+]

--- a/packages/atproto_oauth/__init__.py
+++ b/packages/atproto_oauth/__init__.py
@@ -8,6 +8,12 @@ from atproto_oauth.exceptions import (
     UnsupportedAuthServerError,
 )
 from atproto_oauth.models import OAuthSession, OAuthState
+from atproto_oauth.scopes import (
+    ScopeMissingError,
+    ScopePermissions,
+    ScopePermissionsTransition,
+    ScopesSet,
+)
 
 __all__ = [
     'OAuthClient',
@@ -17,5 +23,9 @@ __all__ = [
     'OAuthStateError',
     'OAuthTokenError',
     'PromptType',
+    'ScopeMissingError',
+    'ScopePermissions',
+    'ScopePermissionsTransition',
+    'ScopesSet',
     'UnsupportedAuthServerError',
 ]

--- a/packages/atproto_oauth/client.py
+++ b/packages/atproto_oauth/client.py
@@ -1,0 +1,611 @@
+"""ATProto OAuth 2.1 client implementation."""
+
+import secrets
+import time
+import typing as t
+from urllib.parse import urlencode
+
+import httpx
+from atproto_identity.resolver import AsyncIdResolver
+
+from atproto_oauth.dpop import DPoPManager
+from atproto_oauth.exceptions import OAuthStateError, OAuthTokenError
+from atproto_oauth.metadata import (
+    discover_authserver_from_pds_async,
+    fetch_authserver_metadata_async,
+)
+from atproto_oauth.models import AuthServerMetadata, OAuthSession, OAuthState, TokenResponse
+from atproto_oauth.pkce import PKCEManager
+from atproto_oauth.security import is_safe_url
+from atproto_oauth.stores.base import SessionStore, StateStore
+
+if t.TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
+
+#: Valid values for the OAuth prompt parameter.
+#: - 'login': Force re-authentication, ignoring any remembered session.
+#: - 'select_account': Show account selection instead of auto-selecting.
+#: - 'consent': Force consent screen even if previously approved.
+#: - 'none': Silent authentication (fails if user interaction required).
+PromptType = t.Literal['login', 'select_account', 'consent', 'none']
+
+
+def _scopes_are_equivalent(requested: str, granted: str) -> bool:
+    """Check if granted scopes satisfy requested scopes.
+
+    Uses set comparison: every non-``atproto`` token in *requested* must appear
+    in *granted*, or (for ``include:`` scopes) at least one granted token must
+    share the same NSID authority prefix.
+
+    Args:
+        requested: The scope string originally requested.
+        granted: The scope string returned by the authorization server.
+
+    Returns:
+        True if granted scopes cover all requested scopes.
+    """
+    if requested == granted:
+        return True
+
+    requested_parts = set(requested.split())
+    granted_parts = set(granted.split())
+
+    # The bare 'atproto' token is implicit
+    requested_parts.discard('atproto')
+    granted_parts.discard('atproto')
+
+    for req in requested_parts:
+        if req in granted_parts:
+            continue
+
+        # include:namespace.permissionSet — the PDS expands these into
+        # resource-specific scopes (repo?collection=..., rpc?lxm=...).
+        # Accept if any granted scope contains the namespace authority.
+        if req.startswith('include:'):
+            authority = req.split(':', 1)[1].rsplit('.', 1)[0]  # e.g. 'app.bsky.feed'
+            if any(authority in g for g in granted_parts):
+                continue
+
+        return False
+
+    return True
+
+
+class OAuthClient:
+    """ATProto OAuth 2.1 client.
+
+    Implements complete OAuth authorization code flow with PKCE and DPoP.
+
+    Args:
+        client_id: OAuth client ID (must be HTTPS URL or localhost).
+        redirect_uri: OAuth redirect URI.
+        scope: OAuth scopes (space-separated).
+        state_store: Store for temporary OAuth state.
+        session_store: Store for OAuth sessions.
+        client_secret_key: Optional EC private key for confidential clients.
+        client_secret_kid: Key ID for the client secret key (required if client_secret_key is provided).
+    """
+
+    def __init__(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        scope: str,
+        state_store: StateStore,
+        session_store: SessionStore,
+        client_secret_key: t.Optional['EllipticCurvePrivateKey'] = None,
+        client_secret_kid: t.Optional[str] = None,
+    ) -> None:
+        self.client_id = client_id
+        self.redirect_uri = redirect_uri
+        self.scope = scope
+        self.state_store = state_store
+        self.session_store = session_store
+        self.client_secret_key = client_secret_key
+        self.client_secret_kid = client_secret_kid
+
+        self._id_resolver = AsyncIdResolver()
+        self._dpop = DPoPManager()
+        self._pkce = PKCEManager()
+
+    async def start_authorization(
+        self,
+        handle_or_did: str,
+        prompt: t.Optional[PromptType] = None,
+    ) -> t.Tuple[str, str]:
+        """Start OAuth authorization flow.
+
+        Args:
+            handle_or_did: User handle (e.g., 'user.bsky.social') or DID.
+            prompt: Optional OAuth prompt parameter to control authorization behavior:
+                - 'login': Force re-authentication, ignoring any remembered session.
+                - 'select_account': Show account selection instead of auto-selecting.
+                - 'consent': Force consent screen even if previously approved.
+                - 'none': Silent authentication (fails if user interaction required).
+
+        Returns:
+            Tuple of (authorization_url, state) for redirecting user.
+
+        Raises:
+            ValueError: If handle/DID resolution fails or URL validation fails.
+            OAuthError: If authorization server discovery or PAR fails.
+        """
+        # 1. Resolve identity
+        if handle_or_did.startswith('did:'):
+            # Input is a DID
+            did = handle_or_did
+        else:
+            # Input is a handle - resolve to DID first
+            resolved_did = await self._id_resolver.handle.resolve(handle_or_did)
+            if not resolved_did:
+                raise ValueError(f'Failed to resolve handle: {handle_or_did}')
+            did = resolved_did
+
+        # 2. Resolve DID to get ATProto data (includes PDS, handle, etc.)
+        atproto_data = await self._id_resolver.did.resolve_atproto_data(did)
+
+        handle = atproto_data.handle or handle_or_did
+        pds_url = atproto_data.pds
+
+        if not pds_url:
+            raise ValueError(f'No PDS endpoint found in DID document for {did}')
+
+        # 3. Discover authorization server
+        authserver_url = await discover_authserver_from_pds_async(pds_url)
+        authserver_url = authserver_url.rstrip('/')
+
+        # 4. Fetch authorization server metadata
+        authserver_meta = await fetch_authserver_metadata_async(authserver_url)
+
+        # 5. Generate PKCE verifier and challenge
+        pkce_verifier, pkce_challenge = self._pkce.generate_pair()
+
+        # 6. Generate DPoP keypair
+        dpop_key = self._dpop.generate_keypair()
+
+        # 7. Generate state token
+        state_token = secrets.token_urlsafe(32)
+
+        # 8. Send PAR (Pushed Authorization Request)
+        request_uri, dpop_nonce = await self._send_par_request(
+            authserver_meta=authserver_meta,
+            login_hint=handle_or_did,
+            pkce_challenge=pkce_challenge,
+            dpop_key=dpop_key,
+            state=state_token,
+            prompt=prompt,
+        )
+
+        # 9. Store state
+        oauth_state = OAuthState(
+            state=state_token,
+            pkce_verifier=pkce_verifier,
+            redirect_uri=self.redirect_uri,
+            scope=self.scope,
+            authserver_iss=authserver_meta.issuer,
+            dpop_private_key=dpop_key,
+            dpop_authserver_nonce=dpop_nonce,
+            did=did,
+            handle=handle,
+            pds_url=pds_url,
+        )
+        await self.state_store.save_state(oauth_state)
+
+        # 10. Build authorization URL
+        auth_params = {
+            'client_id': self.client_id,
+            'request_uri': request_uri,
+        }
+        auth_url = f'{authserver_meta.authorization_endpoint}?{urlencode(auth_params)}'
+
+        if not is_safe_url(auth_url):
+            raise ValueError(f'Generated unsafe authorization URL: {auth_url}')
+
+        return auth_url, state_token
+
+    async def handle_callback(
+        self,
+        code: str,
+        state: str,
+        iss: str,
+    ) -> OAuthSession:
+        """Handle OAuth callback and complete authorization.
+
+        Args:
+            code: Authorization code from callback.
+            state: State parameter from callback.
+            iss: Issuer parameter from callback.
+
+        Returns:
+            OAuth session with tokens.
+
+        Raises:
+            OAuthStateError: If state validation fails.
+            OAuthTokenError: If token exchange fails.
+        """
+        # 1. Retrieve and verify state
+        oauth_state = await self.state_store.get_state(state)
+        if not oauth_state:
+            raise OAuthStateError('Invalid or expired state parameter')
+
+        if oauth_state.authserver_iss != iss:
+            raise OAuthStateError(f'Issuer mismatch: expected {oauth_state.authserver_iss}, got {iss}')
+
+        # Delete state (one-time use)
+        await self.state_store.delete_state(state)
+
+        # 2. Exchange code for tokens
+        token_response, dpop_nonce = await self._exchange_code_for_tokens(
+            code=code,
+            oauth_state=oauth_state,
+        )
+
+        # 3. Verify token response (skip DID check for account creation where did is unknown)
+        if oauth_state.did is not None and token_response.sub != oauth_state.did:
+            raise OAuthTokenError(f'DID mismatch in token: expected {oauth_state.did}, got {token_response.sub}')
+
+        if not _scopes_are_equivalent(self.scope, token_response.scope):
+            raise OAuthTokenError(f'Scope mismatch: expected {self.scope}, got {token_response.scope}')
+
+        # 4. Create and store session
+        session = OAuthSession(
+            did=oauth_state.did or token_response.sub,
+            handle=oauth_state.handle or '',
+            pds_url=oauth_state.pds_url or '',
+            authserver_iss=oauth_state.authserver_iss,
+            access_token=token_response.access_token,
+            refresh_token=token_response.refresh_token or '',
+            dpop_private_key=oauth_state.dpop_private_key,
+            dpop_authserver_nonce=dpop_nonce,
+            scope=token_response.scope,
+        )
+
+        await self.session_store.save_session(session)
+
+        return session
+
+    async def refresh_session(self, session: OAuthSession) -> OAuthSession:
+        """Refresh OAuth session tokens.
+
+        Args:
+            session: Current OAuth session.
+
+        Returns:
+            Updated OAuth session with new tokens.
+
+        Raises:
+            OAuthTokenError: If token refresh fails.
+        """
+        # Fetch current auth server metadata
+        authserver_meta = await fetch_authserver_metadata_async(session.authserver_iss)
+
+        # Prepare refresh token request
+        params = {
+            'grant_type': 'refresh_token',
+            'refresh_token': session.refresh_token,
+        }
+
+        # Make token request with DPoP
+        dpop_nonce, response = await self._make_token_request(
+            token_url=authserver_meta.token_endpoint,
+            params=params,
+            dpop_key=session.dpop_private_key,
+            dpop_nonce=session.dpop_authserver_nonce,
+            issuer=authserver_meta.issuer,
+        )
+
+        if response.status_code not in (200, 201):
+            raise OAuthTokenError(f'Token refresh failed: {response.status_code} {response.text}')
+
+        token_data = response.json()
+        token_response = TokenResponse(
+            access_token=token_data['access_token'],
+            token_type=token_data['token_type'],
+            scope=token_data['scope'],
+            sub=token_data['sub'],
+            refresh_token=token_data.get('refresh_token', session.refresh_token),
+            expires_in=token_data.get('expires_in'),
+        )
+
+        # Verify refreshed scope still covers configured scope
+        if not _scopes_are_equivalent(self.scope, token_response.scope):
+            raise OAuthTokenError(f'Scope reduced after refresh: configured {self.scope}, got {token_response.scope}')
+
+        # Update session
+        session.access_token = token_response.access_token
+        session.refresh_token = token_response.refresh_token
+        session.dpop_authserver_nonce = dpop_nonce
+        session.scope = token_response.scope
+
+        await self.session_store.save_session(session)
+
+        return session
+
+    async def revoke_session(self, session: OAuthSession) -> None:
+        """Revoke OAuth session tokens.
+
+        Args:
+            session: OAuth session to revoke.
+        """
+        authserver_meta = await fetch_authserver_metadata_async(session.authserver_iss)
+
+        if not authserver_meta.revocation_endpoint:
+            # Revocation not supported, just delete local session
+            await self.session_store.delete_session(session.did)
+            return
+
+        # Revoke both access and refresh tokens
+        for token_type in ['access_token', 'refresh_token']:
+            token = session.access_token if token_type == 'access_token' else session.refresh_token
+            if not token:
+                continue
+
+            params = {
+                'token': token,
+                'token_type_hint': token_type,
+            }
+
+            try:
+                await self._make_token_request(
+                    token_url=authserver_meta.revocation_endpoint,
+                    params=params,
+                    dpop_key=session.dpop_private_key,
+                    dpop_nonce=session.dpop_authserver_nonce,
+                    issuer=authserver_meta.issuer,
+                )
+            except (OAuthTokenError, ValueError):
+                # Best-effort revocation; failures are intentionally silent
+                pass
+
+        # Delete local session
+        await self.session_store.delete_session(session.did)
+
+    async def make_authenticated_request(
+        self,
+        session: OAuthSession,
+        method: str,
+        url: str,
+        **kwargs: t.Any,
+    ) -> httpx.Response:
+        """Make authenticated request to PDS with DPoP.
+
+        Args:
+            session: OAuth session.
+            method: HTTP method.
+            url: Request URL.
+            **kwargs: Additional request arguments.
+
+        Returns:
+            HTTP response.
+        """
+        if not is_safe_url(url):
+            raise ValueError(f'Unsafe URL: {url}')
+
+        # Extract user headers once before the loop (preserve for DPoP nonce retry)
+        user_headers = kwargs.pop('headers', {})
+
+        # Try request with retry for DPoP nonce
+        for attempt in range(2):
+            # Create DPoP proof
+            dpop_proof = self._dpop.create_proof(
+                method=method.upper(),
+                url=url,
+                private_key=session.dpop_private_key,
+                nonce=session.dpop_pds_nonce,
+                access_token=session.access_token,
+            )
+
+            # Add auth headers to a copy of user headers
+            headers = user_headers.copy()
+            headers['Authorization'] = f'DPoP {session.access_token}'
+            headers['DPoP'] = dpop_proof
+
+            # Make request
+            async with httpx.AsyncClient() as client:
+                response = await client.request(method, url, headers=headers, **kwargs)
+
+            # Check for DPoP nonce error
+            if self._dpop.is_dpop_nonce_error(response):
+                new_nonce = self._dpop.extract_nonce_from_response(response)
+                if new_nonce and attempt == 0:
+                    session.dpop_pds_nonce = new_nonce
+                    await self.session_store.save_session(session)
+                    continue  # Retry with new nonce
+
+            return response
+
+        return response
+
+    async def _send_par_request(
+        self,
+        authserver_meta: AuthServerMetadata,
+        login_hint: str,
+        pkce_challenge: str,
+        dpop_key: 'EllipticCurvePrivateKey',
+        state: str,
+        prompt: t.Optional[str] = None,
+    ) -> t.Tuple[str, str]:
+        """Send Pushed Authorization Request.
+
+        Args:
+            authserver_meta: Authorization server metadata.
+            login_hint: User handle or DID hint.
+            pkce_challenge: PKCE challenge string.
+            dpop_key: DPoP private key.
+            state: State token for CSRF protection.
+            prompt: Optional prompt parameter for authorization behavior.
+
+        Returns:
+            Tuple of (request_uri, dpop_nonce).
+        """
+        par_url = authserver_meta.pushed_authorization_request_endpoint
+
+        params = {
+            'response_type': 'code',
+            'code_challenge': pkce_challenge,
+            'code_challenge_method': 'S256',
+            'state': state,
+            'redirect_uri': self.redirect_uri,
+            'scope': self.scope,
+            'login_hint': login_hint,
+        }
+
+        if prompt:
+            params['prompt'] = prompt
+
+        # Make PAR request with DPoP
+        dpop_nonce, response = await self._make_token_request(
+            token_url=par_url,
+            params=params,
+            dpop_key=dpop_key,
+            dpop_nonce='',  # Initial request has no nonce
+            issuer=authserver_meta.issuer,
+        )
+
+        if response.status_code not in (200, 201):
+            raise OAuthTokenError(f'PAR request failed: {response.status_code} {response.text}')
+
+        par_response = response.json()
+        return par_response['request_uri'], dpop_nonce
+
+    async def _exchange_code_for_tokens(
+        self,
+        code: str,
+        oauth_state: OAuthState,
+    ) -> t.Tuple[TokenResponse, str]:
+        """Exchange authorization code for tokens.
+
+        Returns:
+            Tuple of (token_response, dpop_nonce).
+        """
+        # Fetch metadata again (could have changed)
+        authserver_meta = await fetch_authserver_metadata_async(oauth_state.authserver_iss)
+
+        params = {
+            'grant_type': 'authorization_code',
+            'code': code,
+            'code_verifier': oauth_state.pkce_verifier,
+            'redirect_uri': self.redirect_uri,
+        }
+
+        dpop_nonce, response = await self._make_token_request(
+            token_url=authserver_meta.token_endpoint,
+            params=params,
+            dpop_key=oauth_state.dpop_private_key,
+            dpop_nonce=oauth_state.dpop_authserver_nonce,
+            issuer=authserver_meta.issuer,
+        )
+
+        if response.status_code not in (200, 201):
+            raise OAuthTokenError(f'Token exchange failed: {response.status_code} {response.text}')
+
+        token_data = response.json()
+        token_response = TokenResponse(
+            access_token=token_data['access_token'],
+            token_type=token_data['token_type'],
+            scope=token_data['scope'],
+            sub=token_data['sub'],
+            refresh_token=token_data.get('refresh_token'),
+            expires_in=token_data.get('expires_in'),
+        )
+
+        return token_response, dpop_nonce
+
+    async def _make_token_request(
+        self,
+        token_url: str,
+        params: t.Dict[str, str],
+        dpop_key: 'EllipticCurvePrivateKey',
+        dpop_nonce: str,
+        issuer: t.Optional[str] = None,
+    ) -> t.Tuple[str, httpx.Response]:
+        """Make token request with DPoP and client assertion.
+
+        Handles DPoP nonce rotation automatically.
+
+        Args:
+            token_url: The token endpoint URL.
+            params: Request parameters.
+            dpop_key: DPoP private key.
+            dpop_nonce: Current DPoP nonce.
+            issuer: Authorization server issuer (required for confidential clients).
+                    Per ATProto OAuth spec, the aud claim must be the issuer.
+
+        Returns:
+            Tuple of (updated_dpop_nonce, response).
+        """
+        if not is_safe_url(token_url):
+            raise ValueError(f'Unsafe token URL: {token_url}')
+
+        # Add client authentication
+        if self.client_secret_key:
+            # Confidential client - use client assertion
+            # Per ATProto OAuth spec: "The aud claim (audience) of the client
+            # assertion JWT must be the Authorization Server's issuer."
+            if not issuer:
+                raise ValueError('issuer required for confidential client authentication')
+            client_assertion = self._create_client_assertion(issuer)
+            params['client_id'] = self.client_id
+            params['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+            params['client_assertion'] = client_assertion
+        else:
+            # Public client
+            params['client_id'] = self.client_id
+
+        # Try request with DPoP nonce retry
+        current_nonce = dpop_nonce
+        for attempt in range(2):
+            # Create DPoP proof
+            dpop_proof = self._dpop.create_proof(
+                method='POST',
+                url=token_url,
+                private_key=dpop_key,
+                nonce=current_nonce if current_nonce else None,
+            )
+
+            # Make request
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    token_url,
+                    data=params,
+                    headers={'DPoP': dpop_proof},
+                )
+
+            # Check for DPoP nonce error
+            if self._dpop.is_dpop_nonce_error(response):
+                new_nonce = self._dpop.extract_nonce_from_response(response)
+                if new_nonce and attempt == 0:
+                    current_nonce = new_nonce
+                    continue  # Retry with new nonce
+
+            # Extract final nonce
+            final_nonce = self._dpop.extract_nonce_from_response(response) or current_nonce
+
+            return final_nonce, response
+
+        return current_nonce, response
+
+    def _create_client_assertion(self, audience: str) -> str:
+        """Create client assertion JWT for confidential client."""
+        if not self.client_secret_key:
+            raise ValueError('Client secret key required for client assertion')
+        if not self.client_secret_kid:
+            raise ValueError('Client secret kid required for client assertion')
+
+        header = {
+            'alg': 'ES256',
+            'typ': 'JWT',
+            'kid': self.client_secret_kid,
+        }
+
+        now = int(time.time())
+        payload = {
+            'iss': self.client_id,
+            'sub': self.client_id,
+            'aud': audience,
+            'jti': secrets.token_urlsafe(16),
+            'iat': now,
+            'exp': now + 60,  # Valid for 60 seconds
+        }
+
+        return self._dpop._sign_jwt(header, payload, self.client_secret_key)

--- a/packages/atproto_oauth/client.py
+++ b/packages/atproto_oauth/client.py
@@ -3,6 +3,7 @@
 import secrets
 import time
 import typing as t
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
 
 import httpx
@@ -248,6 +249,10 @@ class OAuthClient:
             raise OAuthTokenError(f'Scope mismatch: expected {self.scope}, got {token_response.scope}')
 
         # 4. Create and store session
+        expires_at = None
+        if token_response.expires_in is not None:
+            expires_at = datetime.now(timezone.utc) + timedelta(seconds=token_response.expires_in)
+
         session = OAuthSession(
             did=oauth_state.did or token_response.sub,
             handle=oauth_state.handle or '',
@@ -258,6 +263,7 @@ class OAuthClient:
             dpop_private_key=oauth_state.dpop_private_key,
             dpop_authserver_nonce=dpop_nonce,
             scope=token_response.scope,
+            expires_at=expires_at,
         )
 
         await self.session_store.save_session(session)
@@ -316,6 +322,10 @@ class OAuthClient:
         session.refresh_token = token_response.refresh_token
         session.dpop_authserver_nonce = dpop_nonce
         session.scope = token_response.scope
+        if token_response.expires_in is not None:
+            session.expires_at = datetime.now(timezone.utc) + timedelta(seconds=token_response.expires_in)
+        else:
+            session.expires_at = None
 
         await self.session_store.save_session(session)
 

--- a/packages/atproto_oauth/client.py
+++ b/packages/atproto_oauth/client.py
@@ -17,7 +17,10 @@ from atproto_oauth.metadata import (
 )
 from atproto_oauth.models import AuthServerMetadata, OAuthSession, OAuthState, TokenResponse
 from atproto_oauth.pkce import PKCEManager
-from atproto_oauth.security import is_safe_url
+from atproto_oauth.security import (
+    get_hardened_async_client,
+    is_safe_url,
+)
 from atproto_oauth.stores.base import SessionStore, StateStore
 
 if t.TYPE_CHECKING:
@@ -51,7 +54,7 @@ def _scopes_are_equivalent(requested: str, granted: str) -> bool:
     requested_parts = set(requested.split())
     granted_parts = set(granted.split())
 
-    # The bare 'atproto' token is implicit
+    # Remove 'atproto' (required by spec, always present on both sides)
     requested_parts.discard('atproto')
     granted_parts.discard('atproto')
 
@@ -241,14 +244,28 @@ class OAuthClient:
             oauth_state=oauth_state,
         )
 
-        # 3. Verify token response (skip DID check for account creation where did is unknown)
+        # 3. Verify token response
         if oauth_state.did is not None and token_response.sub != oauth_state.did:
             raise OAuthTokenError(f'DID mismatch in token: expected {oauth_state.did}, got {token_response.sub}')
 
         if not _scopes_are_equivalent(self.scope, token_response.scope):
             raise OAuthTokenError(f'Scope mismatch: expected {self.scope}, got {token_response.scope}')
 
-        # 4. Create and store session
+        # 4. Re-verify DID->PDS->AuthServer chain (no cache) to prevent impersonation
+        verified_did = oauth_state.did or token_response.sub
+        atproto_data = await self._id_resolver.did.resolve_atproto_data(verified_did, force_refresh=True)
+        if not atproto_data.pds:
+            raise OAuthTokenError(f'No PDS endpoint found for {verified_did}')
+
+        verified_authserver = await discover_authserver_from_pds_async(atproto_data.pds)
+        verified_authserver = verified_authserver.rstrip('/')
+        if verified_authserver != oauth_state.authserver_iss:
+            raise OAuthTokenError(
+                f'Auth server mismatch on re-verification: '
+                f'expected {oauth_state.authserver_iss}, got {verified_authserver}'
+            )
+
+        # 5. Create and store session
         expires_at = None
         if token_response.expires_in is not None:
             expires_at = datetime.now(timezone.utc) + timedelta(seconds=token_response.expires_in)
@@ -411,7 +428,7 @@ class OAuthClient:
             headers['DPoP'] = dpop_proof
 
             # Make request
-            async with httpx.AsyncClient() as client:
+            async with get_hardened_async_client() as client:
                 response = await client.request(method, url, headers=headers, **kwargs)
 
             # Check for DPoP nonce error
@@ -574,7 +591,7 @@ class OAuthClient:
             )
 
             # Make request
-            async with httpx.AsyncClient() as client:
+            async with get_hardened_async_client() as client:
                 response = await client.post(
                     token_url,
                     data=params,
@@ -602,14 +619,14 @@ class OAuthClient:
         if not self.client_secret_kid:
             raise ValueError('Client secret kid required for client assertion')
 
-        header = {
+        header: t.Dict[str, str] = {
             'alg': 'ES256',
             'typ': 'JWT',
             'kid': self.client_secret_kid,
         }
 
         now = int(time.time())
-        payload = {
+        payload: t.Dict[str, t.Union[str, int]] = {
             'iss': self.client_id,
             'sub': self.client_id,
             'aud': audience,

--- a/packages/atproto_oauth/client.py
+++ b/packages/atproto_oauth/client.py
@@ -37,17 +37,27 @@ PromptType = t.Literal['login', 'select_account', 'consent', 'none']
 def _scopes_are_equivalent(requested: str, granted: str) -> bool:
     """Check if granted scopes satisfy requested scopes.
 
-    Uses set comparison: every non-``atproto`` token in *requested* must appear
-    in *granted*, or (for ``include:`` scopes) at least one granted token must
-    share the same NSID authority prefix.
+    Handles permission set expansion where PDS expands ``include:namespace.permissionSet``
+    into ``repo?collection=...`` format, and equivalence between positional
+    (``repo:nsid``) and query (``repo?collection=nsid``) forms.
 
     Args:
-        requested: The scope string originally requested.
-        granted: The scope string returned by the authorization server.
+        requested: The scope string originally requested (may contain ``include:`` scopes).
+        granted: The scope string returned by the PDS (with expanded permissions).
 
     Returns:
-        True if granted scopes cover all requested scopes.
+        True if granted scopes satisfy all requested permissions.
     """
+    from atproto_oauth.scopes.permissions import (
+        AccountPermission,
+        BlobPermission,
+        IdentityPermission,
+        IncludeScope,
+        RepoPermission,
+        RpcPermission,
+    )
+
+    # fast path: exact match
     if requested == granted:
         return True
 
@@ -58,19 +68,81 @@ def _scopes_are_equivalent(requested: str, granted: str) -> bool:
     requested_parts.discard('atproto')
     granted_parts.discard('atproto')
 
-    for req in requested_parts:
-        if req in granted_parts:
+    # Parse all granted scopes into permission objects by type
+    granted_repo: t.List[RepoPermission] = []
+    granted_blob: t.List[BlobPermission] = []
+    granted_rpc: t.List[RpcPermission] = []
+    granted_account: t.List[AccountPermission] = []
+    granted_identity: t.List[IdentityPermission] = []
+
+    for scope in granted_parts:
+        if (p := RepoPermission.from_string(scope)) is not None:
+            granted_repo.append(p)
+        elif (p := BlobPermission.from_string(scope)) is not None:
+            granted_blob.append(p)
+        elif (p := RpcPermission.from_string(scope)) is not None:
+            granted_rpc.append(p)
+        elif (p := AccountPermission.from_string(scope)) is not None:
+            granted_account.append(p)
+        elif (p := IdentityPermission.from_string(scope)) is not None:
+            granted_identity.append(p)
+        # transition: and other tokens are kept as-is for exact matching
+
+    for req_scope in requested_parts:
+        # Transition scopes: exact match
+        if req_scope.startswith('transition:'):
+            if req_scope not in granted_parts:
+                return False
             continue
 
-        # include:namespace.permissionSet — the PDS expands these into
-        # resource-specific scopes (repo?collection=..., rpc?lxm=...).
-        # Accept if any granted scope contains the namespace authority.
-        if req.startswith('include:'):
-            authority = req.split(':', 1)[1].rsplit('.', 1)[0]  # e.g. 'app.bsky.feed'
-            if any(authority in g for g in granted_parts):
-                continue
+        # Include scopes: verify PDS expanded them into matching repo/rpc scopes
+        if (inc := IncludeScope.from_string(req_scope)) is not None:
+            # Check if any granted repo scope has a collection in this namespace
+            found = any(any(inc.is_parent_authority_of(c) for c in rp.collection) for rp in granted_repo)
+            if not found:
+                # Also check granted rpc scopes
+                found = any(any(inc.is_parent_authority_of(lxm) for lxm in rp.lxm) for rp in granted_rpc)
+            if not found:
+                return False
+            continue
 
-        return False
+        # Resource permissions: parse and compare
+        if (req_perm := RepoPermission.from_string(req_scope)) is not None:
+            # Check if any granted repo permission covers all collection+action combos
+            for coll in req_perm.collection:
+                for action in req_perm.action:
+                    if not any(gp.matches(coll, action) for gp in granted_repo):
+                        return False
+            continue
+
+        if (req_perm := BlobPermission.from_string(req_scope)) is not None:
+            if req_scope in granted_parts:
+                continue
+            # Check if any granted blob permission covers all requested MIME types
+            if all(any(gp.matches(accept) for gp in granted_blob) for accept in req_perm.accept):
+                continue
+            return False
+
+        if (req_perm := RpcPermission.from_string(req_scope)) is not None:
+            for lxm in req_perm.lxm:
+                if not any(gp.matches(lxm, req_perm.aud) for gp in granted_rpc):
+                    return False
+            continue
+
+        if (req_perm := AccountPermission.from_string(req_scope)) is not None:
+            for action in req_perm.action:
+                if not any(gp.matches(req_perm.attr, action) for gp in granted_account):
+                    return False
+            continue
+
+        if (req_perm := IdentityPermission.from_string(req_scope)) is not None:
+            if not any(gp.matches(req_perm.attr) for gp in granted_identity):
+                return False
+            continue
+
+        # Unknown scope token: require exact match
+        if req_scope not in granted_parts:
+            return False
 
     return True
 

--- a/packages/atproto_oauth/dpop.py
+++ b/packages/atproto_oauth/dpop.py
@@ -1,0 +1,213 @@
+"""DPoP (Demonstrating Proof-of-Possession) implementation."""
+
+import hashlib
+import json
+import secrets
+import time
+import typing as t
+from base64 import urlsafe_b64encode
+from urllib.parse import urlparse
+
+import httpx
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+if t.TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
+
+
+class DPoPManager:
+    """Manages DPoP proof generation for OAuth."""
+
+    @staticmethod
+    def generate_keypair() -> 'EllipticCurvePrivateKey':
+        """Generate ES256 keypair for DPoP.
+
+        Returns:
+            EC private key (P-256 curve).
+        """
+        return ec.generate_private_key(ec.SECP256R1())
+
+    @staticmethod
+    def _key_to_jwk(private_key: 'EllipticCurvePrivateKey', include_private: bool = False) -> t.Dict[str, t.Any]:
+        """Convert EC private key to JWK format.
+
+        Args:
+            private_key: The EC private key.
+            include_private: Whether to include private key components.
+
+        Returns:
+            JWK dictionary.
+        """
+        public_key = private_key.public_key()
+        public_numbers = public_key.public_numbers()
+
+        # Convert to bytes and base64url encode
+        def int_to_base64url(n: int, length: int) -> str:
+            byte_len = (length + 7) // 8
+            return urlsafe_b64encode(n.to_bytes(byte_len, 'big')).decode('utf-8').rstrip('=')
+
+        jwk = {
+            'kty': 'EC',
+            'crv': 'P-256',
+            'x': int_to_base64url(public_numbers.x, 256),
+            'y': int_to_base64url(public_numbers.y, 256),
+        }
+
+        if include_private:
+            private_numbers = private_key.private_numbers()
+            jwk['d'] = int_to_base64url(private_numbers.private_value, 256)
+
+        return jwk
+
+    @staticmethod
+    def _sign_jwt(
+        header: t.Dict[str, t.Any], payload: t.Dict[str, t.Any], private_key: 'EllipticCurvePrivateKey'
+    ) -> str:
+        """Sign a JWT using ES256.
+
+        Args:
+            header: JWT header.
+            payload: JWT payload.
+            private_key: EC private key for signing.
+
+        Returns:
+            Complete JWT string.
+        """
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec
+
+        # Encode header and payload
+        header_b64 = urlsafe_b64encode(json.dumps(header, separators=(',', ':')).encode()).decode().rstrip('=')
+        payload_b64 = urlsafe_b64encode(json.dumps(payload, separators=(',', ':')).encode()).decode().rstrip('=')
+
+        # Create signing input
+        signing_input = f'{header_b64}.{payload_b64}'.encode()
+
+        # Sign (returns DER-encoded signature)
+        der_signature = private_key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+
+        # Convert DER signature to IEEE P1363 format (raw r|s concatenated)
+        # ES256 uses P-256 curve, so r and s are each 32 bytes
+        r, s = decode_dss_signature(der_signature)
+
+        # Convert r and s to 32-byte big-endian sequences
+        r_bytes = r.to_bytes(32, 'big')
+        s_bytes = s.to_bytes(32, 'big')
+
+        # Concatenate and encode
+        raw_signature = r_bytes + s_bytes
+        signature_b64 = urlsafe_b64encode(raw_signature).decode().rstrip('=')
+
+        return f'{header_b64}.{payload_b64}.{signature_b64}'
+
+    @classmethod
+    def create_proof(
+        cls,
+        method: str,
+        url: str,
+        private_key: 'EllipticCurvePrivateKey',
+        nonce: t.Optional[str] = None,
+        access_token: t.Optional[str] = None,
+    ) -> str:
+        """Generate DPoP proof JWT.
+
+        Args:
+            method: HTTP method (e.g., 'GET', 'POST').
+            url: Full URL of the request.
+            private_key: EC private key for signing.
+            nonce: Optional server-provided nonce.
+            access_token: Optional access token (for 'ath' claim).
+
+        Returns:
+            DPoP proof JWT string.
+        """
+        # Get public key JWK
+        public_jwk = cls._key_to_jwk(private_key, include_private=False)
+
+        # Create header
+        header = {
+            'typ': 'dpop+jwt',
+            'alg': 'ES256',
+            'jwk': public_jwk,
+        }
+
+        # Strip query and fragment from URL per RFC 9449
+        parsed_url = urlparse(url)
+        htu = f'{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}'
+
+        # Create payload
+        now = int(time.time())
+        payload = {
+            'jti': secrets.token_urlsafe(16),
+            'htm': method.upper(),
+            'htu': htu,
+            'iat': now,
+            'exp': now + 60,  # Valid for 60 seconds
+        }
+
+        # Add optional claims
+        if nonce:
+            payload['nonce'] = nonce
+
+        if access_token:
+            # Hash access token for 'ath' claim (same as PKCE S256)
+            ath_hash = hashlib.sha256(access_token.encode('utf-8')).digest()
+            payload['ath'] = urlsafe_b64encode(ath_hash).decode('utf-8').rstrip('=')
+
+        return cls._sign_jwt(header, payload, private_key)
+
+    @staticmethod
+    def extract_nonce_from_response(response: httpx.Response) -> t.Optional[str]:
+        """Extract DPoP nonce from HTTP response.
+
+        Checks both the 'DPoP-Nonce' header and error responses.
+
+        Args:
+            response: HTTP response object.
+
+        Returns:
+            DPoP nonce string if present, None otherwise.
+        """
+        # Check DPoP-Nonce header
+        if nonce := response.headers.get('DPoP-Nonce'):
+            return nonce
+
+        # Check for error response with use_dpop_nonce
+        if response.status_code in (400, 401):
+            try:
+                error_body = response.json()
+                if isinstance(error_body, dict) and error_body.get('error') == 'use_dpop_nonce':
+                    return response.headers.get('DPoP-Nonce')
+            except Exception:
+                pass
+
+        return None
+
+    @staticmethod
+    def is_dpop_nonce_error(response: httpx.Response) -> bool:
+        """Check if response indicates DPoP nonce error.
+
+        Args:
+            response: HTTP response object.
+
+        Returns:
+            True if response indicates need for new DPoP nonce.
+        """
+        if response.status_code not in (400, 401):
+            return False
+
+        # Check WWW-Authenticate header
+        if www_auth := response.headers.get('WWW-Authenticate', ''):
+            if 'use_dpop_nonce' in www_auth.lower():
+                return True
+
+        # Check JSON error response
+        try:
+            error_body = response.json()
+            if isinstance(error_body, dict) and error_body.get('error') == 'use_dpop_nonce':
+                return True
+        except Exception:
+            pass
+
+        return False

--- a/packages/atproto_oauth/dpop.py
+++ b/packages/atproto_oauth/dpop.py
@@ -179,7 +179,7 @@ class DPoPManager:
                 error_body = response.json()
                 if isinstance(error_body, dict) and error_body.get('error') == 'use_dpop_nonce':
                     return response.headers.get('DPoP-Nonce')
-            except Exception:
+            except (ValueError, KeyError):
                 pass
 
         return None
@@ -207,7 +207,7 @@ class DPoPManager:
             error_body = response.json()
             if isinstance(error_body, dict) and error_body.get('error') == 'use_dpop_nonce':
                 return True
-        except Exception:
+        except (ValueError, KeyError):
             pass
 
         return False

--- a/packages/atproto_oauth/exceptions.py
+++ b/packages/atproto_oauth/exceptions.py
@@ -1,0 +1,16 @@
+"""OAuth-specific exceptions."""
+
+from atproto_core.exceptions import AtProtocolError
+
+
+class OAuthError(AtProtocolError):
+    """Base exception for OAuth errors."""
+
+
+class OAuthStateError(OAuthError): ...
+
+
+class OAuthTokenError(OAuthError): ...
+
+
+class UnsupportedAuthServerError(OAuthError): ...

--- a/packages/atproto_oauth/metadata.py
+++ b/packages/atproto_oauth/metadata.py
@@ -1,0 +1,184 @@
+"""Authorization server metadata discovery."""
+
+import httpx
+
+from atproto_oauth.exceptions import UnsupportedAuthServerError
+from atproto_oauth.models import AuthServerMetadata
+from atproto_oauth.security import is_safe_url, validate_authserver_metadata
+
+
+async def discover_authserver_from_pds_async(pds_url: str, timeout: float = 5.0) -> str:
+    """Discover authorization server URL from PDS.
+
+    Args:
+        pds_url: PDS endpoint URL.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Authorization server URL.
+
+    Raises:
+        ValueError: If PDS URL is unsafe or response is invalid.
+        httpx.HTTPError: If request fails.
+    """
+    if not is_safe_url(pds_url):
+        raise ValueError(f'Unsafe PDS URL: {pds_url}')
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(f'{pds_url}/.well-known/oauth-protected-resource')
+        response.raise_for_status()
+
+        if response.status_code != 200:
+            raise ValueError(f'PDS returned non-200 status: {response.status_code}')
+
+        data = response.json()
+        if not isinstance(data, dict) or 'authorization_servers' not in data:
+            raise ValueError('Invalid oauth-protected-resource response')
+
+        auth_servers = data['authorization_servers']
+        if not auth_servers or not isinstance(auth_servers, list):
+            raise ValueError('No authorization servers found')
+
+        return auth_servers[0]
+
+
+def discover_authserver_from_pds(pds_url: str, timeout: float = 5.0) -> str:
+    """Discover authorization server URL from PDS (synchronous).
+
+    Args:
+        pds_url: PDS endpoint URL.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Authorization server URL.
+    """
+    if not is_safe_url(pds_url):
+        raise ValueError(f'Unsafe PDS URL: {pds_url}')
+
+    with httpx.Client(timeout=timeout) as client:
+        response = client.get(f'{pds_url}/.well-known/oauth-protected-resource')
+        response.raise_for_status()
+
+        if response.status_code != 200:
+            raise ValueError(f'PDS returned non-200 status: {response.status_code}')
+
+        data = response.json()
+        if not isinstance(data, dict) or 'authorization_servers' not in data:
+            raise ValueError('Invalid oauth-protected-resource response')
+
+        auth_servers = data['authorization_servers']
+        if not auth_servers or not isinstance(auth_servers, list):
+            raise ValueError('No authorization servers found')
+
+        return auth_servers[0]
+
+
+async def fetch_authserver_metadata_async(authserver_url: str, timeout: float = 5.0) -> AuthServerMetadata:
+    """Fetch and validate authorization server metadata.
+
+    Args:
+        authserver_url: Authorization server URL.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Validated metadata object.
+
+    Raises:
+        ValueError: If URL is unsafe.
+        UnsupportedAuthServerError: If metadata doesn't meet requirements.
+        httpx.HTTPError: If request fails.
+    """
+    if not is_safe_url(authserver_url):
+        raise ValueError(f'Unsafe authorization server URL: {authserver_url}')
+
+    fetch_url = f'{authserver_url}/.well-known/oauth-authorization-server'
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(fetch_url)
+        response.raise_for_status()
+
+        metadata_dict = response.json()
+
+        # Validate against ATProto requirements
+        try:
+            validate_authserver_metadata(metadata_dict, fetch_url)
+        except ValueError as e:
+            raise UnsupportedAuthServerError(str(e)) from e
+
+        # Parse into model
+        return AuthServerMetadata(
+            issuer=metadata_dict['issuer'],
+            authorization_endpoint=metadata_dict['authorization_endpoint'],
+            token_endpoint=metadata_dict['token_endpoint'],
+            pushed_authorization_request_endpoint=metadata_dict['pushed_authorization_request_endpoint'],
+            response_types_supported=metadata_dict['response_types_supported'],
+            grant_types_supported=metadata_dict['grant_types_supported'],
+            code_challenge_methods_supported=metadata_dict['code_challenge_methods_supported'],
+            token_endpoint_auth_methods_supported=metadata_dict['token_endpoint_auth_methods_supported'],
+            token_endpoint_auth_signing_alg_values_supported=metadata_dict[
+                'token_endpoint_auth_signing_alg_values_supported'
+            ],
+            scopes_supported=metadata_dict['scopes_supported'],
+            dpop_signing_alg_values_supported=metadata_dict['dpop_signing_alg_values_supported'],
+            authorization_response_iss_parameter_supported=metadata_dict[
+                'authorization_response_iss_parameter_supported'
+            ],
+            require_pushed_authorization_requests=metadata_dict['require_pushed_authorization_requests'],
+            client_id_metadata_document_supported=metadata_dict['client_id_metadata_document_supported'],
+            revocation_endpoint=metadata_dict.get('revocation_endpoint'),
+            jwks_uri=metadata_dict.get('jwks_uri'),
+            require_request_uri_registration=metadata_dict.get('require_request_uri_registration'),
+        )
+
+
+def fetch_authserver_metadata(authserver_url: str, timeout: float = 5.0) -> AuthServerMetadata:
+    """Fetch and validate authorization server metadata (synchronous).
+
+    Args:
+        authserver_url: Authorization server URL.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Validated metadata object.
+    """
+    if not is_safe_url(authserver_url):
+        raise ValueError(f'Unsafe authorization server URL: {authserver_url}')
+
+    fetch_url = f'{authserver_url}/.well-known/oauth-authorization-server'
+
+    with httpx.Client(timeout=timeout) as client:
+        response = client.get(fetch_url)
+        response.raise_for_status()
+
+        metadata_dict = response.json()
+
+        # Validate against ATProto requirements
+        try:
+            validate_authserver_metadata(metadata_dict, fetch_url)
+        except ValueError as e:
+            raise UnsupportedAuthServerError(str(e)) from e
+
+        # Parse into model
+        return AuthServerMetadata(
+            issuer=metadata_dict['issuer'],
+            authorization_endpoint=metadata_dict['authorization_endpoint'],
+            token_endpoint=metadata_dict['token_endpoint'],
+            pushed_authorization_request_endpoint=metadata_dict['pushed_authorization_request_endpoint'],
+            response_types_supported=metadata_dict['response_types_supported'],
+            grant_types_supported=metadata_dict['grant_types_supported'],
+            code_challenge_methods_supported=metadata_dict['code_challenge_methods_supported'],
+            token_endpoint_auth_methods_supported=metadata_dict['token_endpoint_auth_methods_supported'],
+            token_endpoint_auth_signing_alg_values_supported=metadata_dict[
+                'token_endpoint_auth_signing_alg_values_supported'
+            ],
+            scopes_supported=metadata_dict['scopes_supported'],
+            dpop_signing_alg_values_supported=metadata_dict['dpop_signing_alg_values_supported'],
+            authorization_response_iss_parameter_supported=metadata_dict[
+                'authorization_response_iss_parameter_supported'
+            ],
+            require_pushed_authorization_requests=metadata_dict['require_pushed_authorization_requests'],
+            client_id_metadata_document_supported=metadata_dict['client_id_metadata_document_supported'],
+            revocation_endpoint=metadata_dict.get('revocation_endpoint'),
+            jwks_uri=metadata_dict.get('jwks_uri'),
+            require_request_uri_registration=metadata_dict.get('require_request_uri_registration'),
+        )

--- a/packages/atproto_oauth/metadata.py
+++ b/packages/atproto_oauth/metadata.py
@@ -1,10 +1,13 @@
 """Authorization server metadata discovery."""
 
-import httpx
-
 from atproto_oauth.exceptions import UnsupportedAuthServerError
 from atproto_oauth.models import AuthServerMetadata
-from atproto_oauth.security import is_safe_url, validate_authserver_metadata
+from atproto_oauth.security import (
+    get_hardened_async_client,
+    get_hardened_client,
+    is_safe_url,
+    validate_authserver_metadata,
+)
 
 
 async def discover_authserver_from_pds_async(pds_url: str, timeout: float = 5.0) -> str:
@@ -24,7 +27,7 @@ async def discover_authserver_from_pds_async(pds_url: str, timeout: float = 5.0)
     if not is_safe_url(pds_url):
         raise ValueError(f'Unsafe PDS URL: {pds_url}')
 
-    async with httpx.AsyncClient(timeout=timeout) as client:
+    async with get_hardened_async_client(timeout=timeout) as client:
         response = await client.get(f'{pds_url}/.well-known/oauth-protected-resource')
         response.raise_for_status()
 
@@ -55,7 +58,7 @@ def discover_authserver_from_pds(pds_url: str, timeout: float = 5.0) -> str:
     if not is_safe_url(pds_url):
         raise ValueError(f'Unsafe PDS URL: {pds_url}')
 
-    with httpx.Client(timeout=timeout) as client:
+    with get_hardened_client(timeout=timeout) as client:
         response = client.get(f'{pds_url}/.well-known/oauth-protected-resource')
         response.raise_for_status()
 
@@ -93,7 +96,7 @@ async def fetch_authserver_metadata_async(authserver_url: str, timeout: float = 
 
     fetch_url = f'{authserver_url}/.well-known/oauth-authorization-server'
 
-    async with httpx.AsyncClient(timeout=timeout) as client:
+    async with get_hardened_async_client(timeout=timeout) as client:
         response = await client.get(fetch_url)
         response.raise_for_status()
 
@@ -146,7 +149,7 @@ def fetch_authserver_metadata(authserver_url: str, timeout: float = 5.0) -> Auth
 
     fetch_url = f'{authserver_url}/.well-known/oauth-authorization-server'
 
-    with httpx.Client(timeout=timeout) as client:
+    with get_hardened_client(timeout=timeout) as client:
         response = client.get(fetch_url)
         response.raise_for_status()
 

--- a/packages/atproto_oauth/models.py
+++ b/packages/atproto_oauth/models.py
@@ -1,0 +1,78 @@
+"""OAuth data models."""
+
+import typing as t
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+if t.TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
+
+
+@dataclass
+class AuthServerMetadata:
+    """Authorization Server metadata from discovery."""
+
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    pushed_authorization_request_endpoint: str
+    response_types_supported: t.List[str]
+    grant_types_supported: t.List[str]
+    code_challenge_methods_supported: t.List[str]
+    token_endpoint_auth_methods_supported: t.List[str]
+    token_endpoint_auth_signing_alg_values_supported: t.List[str]
+    scopes_supported: t.List[str]
+    dpop_signing_alg_values_supported: t.List[str]
+    authorization_response_iss_parameter_supported: bool
+    require_pushed_authorization_requests: bool
+    client_id_metadata_document_supported: bool
+    revocation_endpoint: t.Optional[str] = None
+    jwks_uri: t.Optional[str] = None
+    require_request_uri_registration: t.Optional[bool] = None
+
+
+@dataclass
+class OAuthState:
+    """OAuth state for CSRF protection during authorization flow."""
+
+    state: str
+    pkce_verifier: str
+    redirect_uri: str
+    scope: str
+    authserver_iss: str
+    dpop_private_key: 'EllipticCurvePrivateKey'
+    dpop_authserver_nonce: str
+    did: t.Optional[str] = None
+    handle: t.Optional[str] = None
+    pds_url: t.Optional[str] = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
+class OAuthSession:
+    """OAuth session with tokens and metadata."""
+
+    did: str
+    handle: str
+    pds_url: str
+    authserver_iss: str
+    access_token: str
+    refresh_token: str
+    dpop_private_key: 'EllipticCurvePrivateKey'
+    dpop_authserver_nonce: str
+    scope: str
+    dpop_pds_nonce: t.Optional[str] = None
+    expires_at: t.Optional[datetime] = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
+class TokenResponse:
+    """Token response from authorization server."""
+
+    access_token: str
+    token_type: str
+    scope: str
+    sub: str  # DID
+    refresh_token: t.Optional[str] = None
+    expires_in: t.Optional[int] = None

--- a/packages/atproto_oauth/pkce.py
+++ b/packages/atproto_oauth/pkce.py
@@ -1,0 +1,57 @@
+"""PKCE (Proof Key for Code Exchange) implementation."""
+
+import base64
+import hashlib
+import secrets
+import typing as t
+
+
+class PKCEManager:
+    """Manages PKCE code verifier and challenge generation."""
+
+    @staticmethod
+    def generate_verifier(length: int = 128) -> str:
+        """Generate a PKCE code verifier.
+
+        Args:
+            length: Length of the verifier (43-128 characters).
+
+        Returns:
+            Base64url-encoded verifier string.
+
+        Raises:
+            ValueError: If length is not between 43 and 128.
+        """
+        if not 43 <= length <= 128:
+            raise ValueError('PKCE verifier length must be between 43 and 128')
+
+        # Generate random bytes and encode as base64url
+        verifier_bytes = secrets.token_bytes(length)
+        return base64.urlsafe_b64encode(verifier_bytes).decode('utf-8').rstrip('=')[:length]
+
+    @staticmethod
+    def generate_challenge(verifier: str) -> str:
+        """Generate S256 PKCE code challenge from verifier.
+
+        Args:
+            verifier: The code verifier string.
+
+        Returns:
+            Base64url-encoded SHA256 hash of the verifier.
+        """
+        digest = hashlib.sha256(verifier.encode('utf-8')).digest()
+        return base64.urlsafe_b64encode(digest).decode('utf-8').rstrip('=')
+
+    @classmethod
+    def generate_pair(cls, length: int = 128) -> t.Tuple[str, str]:
+        """Generate both verifier and challenge.
+
+        Args:
+            length: Length of the verifier.
+
+        Returns:
+            Tuple of (verifier, challenge).
+        """
+        verifier = cls.generate_verifier(length)
+        challenge = cls.generate_challenge(verifier)
+        return verifier, challenge

--- a/packages/atproto_oauth/scopes/__init__.py
+++ b/packages/atproto_oauth/scopes/__init__.py
@@ -1,0 +1,31 @@
+"""ATProto OAuth scope parsing and permission checking.
+
+Provides spec-compliant parsing of ATProto OAuth scope strings per
+the ATProto permissions specification.
+"""
+
+from atproto_oauth.scopes.exceptions import ScopeMissingError
+from atproto_oauth.scopes.permissions import (
+    AccountPermission,
+    BlobPermission,
+    IdentityPermission,
+    IncludeScope,
+    RepoPermission,
+    RpcPermission,
+)
+from atproto_oauth.scopes.scope_permissions import ScopePermissions
+from atproto_oauth.scopes.scopes_set import ScopesSet
+from atproto_oauth.scopes.transition import ScopePermissionsTransition
+
+__all__ = [
+    'AccountPermission',
+    'BlobPermission',
+    'IdentityPermission',
+    'IncludeScope',
+    'RepoPermission',
+    'RpcPermission',
+    'ScopeMissingError',
+    'ScopePermissions',
+    'ScopePermissionsTransition',
+    'ScopesSet',
+]

--- a/packages/atproto_oauth/scopes/_mime.py
+++ b/packages/atproto_oauth/scopes/_mime.py
@@ -1,0 +1,59 @@
+"""MIME type and Accept header matching for blob scopes."""
+
+import typing as t
+
+
+def is_accept(value: str) -> bool:
+    """Check if value is a valid accept pattern (``*/*``, ``image/*``, ``image/png``)."""
+    if value == '*/*':
+        return True
+    if not _is_string_slash_string(value):
+        return False
+    return '*' not in value or value.endswith('/*')
+
+
+def is_mime(value: str) -> bool:
+    """Check if value is a concrete MIME type (no wildcards)."""
+    return _is_string_slash_string(value) and '*' not in value
+
+
+def matches_accept(accept: str, mime: str) -> bool:
+    """Check if a MIME type matches an accept pattern."""
+    if not is_mime(mime):
+        return False
+    return _matches_accept_unsafe(accept, mime)
+
+
+def matches_any_accept(patterns: t.Iterable[str], mime: str) -> bool:
+    """Check if a MIME type matches any of the accept patterns."""
+    if not is_mime(mime):
+        return False
+    for accept in patterns:
+        if _matches_accept_unsafe(accept, mime):
+            return True
+    return False
+
+
+def _is_string_slash_string(value: str) -> bool:
+    """Check if value has exactly one slash with non-empty parts on both sides."""
+    slash_idx = value.find('/')
+    if slash_idx == -1:
+        return False
+    if slash_idx == 0:
+        return False
+    if slash_idx == len(value) - 1:
+        return False
+    if '/' in value[slash_idx + 1 :]:
+        return False
+    if ' ' in value:
+        return False
+    return True
+
+
+def _matches_accept_unsafe(accept: str, mime: str) -> bool:
+    """Match without re-validating mime."""
+    if accept == '*/*':
+        return True
+    if accept.endswith('/*'):
+        return mime.startswith(accept[:-1])
+    return accept == mime

--- a/packages/atproto_oauth/scopes/_parser.py
+++ b/packages/atproto_oauth/scopes/_parser.py
@@ -1,0 +1,158 @@
+"""Generic schema-driven parser for scope parameters.
+
+Each permission type declares a schema dict describing its parameters, then
+delegates parsing and formatting to :class:`Parser`.
+"""
+
+import typing as t
+from dataclasses import dataclass
+
+from atproto_oauth.scopes._syntax import ScopeStringSyntax
+
+
+@dataclass(frozen=True)
+class ParamSchema:
+    """Schema for a single parameter."""
+
+    multiple: bool
+    required: bool
+    validate: t.Callable[[str], bool]
+    default: t.Any = None
+    normalize: t.Optional[t.Callable[..., t.Any]] = None
+
+
+class Parser:
+    """Schema-driven scope string parser/formatter.
+
+    Args:
+        prefix: The resource type prefix (e.g. ``"repo"``, ``"blob"``).
+        schema: Mapping of parameter names to their schemas.
+        positional_name: Parameter name that can appear as positional.
+    """
+
+    def __init__(
+        self,
+        prefix: str,
+        schema: t.Dict[str, ParamSchema],
+        positional_name: t.Optional[str] = None,
+    ) -> None:
+        self.prefix = prefix
+        self.schema = schema
+        self.positional_name = positional_name
+        self.schema_keys = frozenset(schema)
+
+    def parse(self, syntax: ScopeStringSyntax) -> t.Optional[t.Dict[str, t.Any]]:
+        """Parse a syntax object into validated parameter values.
+
+        Returns None on any validation failure (try-parse pattern).
+        """
+        # Reject unknown keys
+        for key in syntax.keys():
+            if key not in self.schema_keys:
+                return None
+
+        result: t.Dict[str, t.Any] = {}
+
+        for key, defn in self.schema.items():
+            if defn.multiple:
+                param = syntax.get_multi(key)
+            else:
+                param = syntax.get_single(key)
+
+            if param is not None:
+                # Named parameter present
+                if key == self.positional_name and syntax.positional is not None:
+                    # Positional cannot coexist with named
+                    return None
+
+                if defn.multiple:
+                    values = param if isinstance(param, list) else [param]
+                    if not values:
+                        return None
+                    if not all(defn.validate(v) for v in values):
+                        return None
+                    result[key] = values
+                else:
+                    if not defn.validate(param):
+                        return None
+                    result[key] = param
+            elif key == self.positional_name and syntax.positional is not None:
+                # Use positional value
+                positional = syntax.positional
+                if not defn.validate(positional):
+                    return None
+                result[key] = [positional] if defn.multiple else positional
+            elif defn.required:
+                return None
+            else:
+                result[key] = defn.default
+
+        return result
+
+    def format(self, values: t.Dict[str, t.Any]) -> str:
+        """Format validated values back into a canonical scope string."""
+        params: t.List[t.Tuple[str, str]] = []
+        positional: t.Optional[str] = None
+
+        for key in self.schema:
+            value = values.get(key)
+            if value is None:
+                continue
+
+            defn = self.schema[key]
+
+            # Normalize
+            normalized = defn.normalize(value) if defn.normalize else value
+
+            # Skip default values
+            if not defn.required and defn.default is not None:
+                if defn.multiple:
+                    if _array_param_equals(defn.default, normalized):
+                        continue
+                elif normalized == defn.default:
+                    continue
+
+            if isinstance(normalized, (list, tuple)):
+                if key == self.positional_name and len(normalized) == 1:
+                    positional = str(normalized[0])
+                else:
+                    # Deduplicate preserving order
+                    seen: t.Set[str] = set()
+                    for v in normalized:
+                        s = str(v)
+                        if s not in seen:
+                            seen.add(s)
+                            params.append((key, s))
+            else:
+                if key == self.positional_name:
+                    positional = str(normalized)
+                else:
+                    params.append((key, str(normalized)))
+
+        syntax = ScopeStringSyntax(
+            prefix=self.prefix,
+            positional=positional,
+            params=_pairs_to_dict(params) if params else {},
+        )
+        return str(syntax)
+
+    def format_values(self, values: t.Dict[str, t.Any]) -> str:
+        """Alias for format() for API compatibility."""
+        return self.format(values)
+
+
+def _array_param_equals(a: t.Sequence[t.Any], b: t.Sequence[t.Any]) -> bool:
+    """Check if two param arrays contain the same elements (order-independent)."""
+    if len(a) != len(b):
+        return False
+    a_set = set(str(x) for x in a)
+    b_set = set(str(x) for x in b)
+    return a_set == b_set
+
+
+def _pairs_to_dict(pairs: t.List[t.Tuple[str, str]]) -> t.Dict[str, t.List[str]]:
+    """Convert a list of key-value pairs into a multi-value dict."""
+    result: t.Dict[str, t.List[str]] = {}
+    for key, val in pairs:
+        result.setdefault(key, []).append(val)
+    return result

--- a/packages/atproto_oauth/scopes/_syntax.py
+++ b/packages/atproto_oauth/scopes/_syntax.py
@@ -1,0 +1,150 @@
+"""Scope string tokenizer.
+
+Parses scope strings of the form ``resource[:positional][?key=val&key=val]``
+into structured parts.
+
+Examples::
+
+    ScopeStringSyntax.from_string("repo:fm.plyr.track?action=create")
+    # -> prefix="repo", positional="fm.plyr.track", params={"action": ["create"]}
+
+    ScopeStringSyntax.from_string("repo?collection=a.b.c&collection=d.e.f")
+    # -> prefix="repo", positional=None, params={"collection": ["a.b.c", "d.e.f"]}
+"""
+
+import typing as t
+from dataclasses import dataclass, field
+from urllib.parse import parse_qs, unquote, urlencode
+
+
+@dataclass(frozen=True)
+class ScopeStringSyntax:
+    """Parsed scope string token."""
+
+    prefix: str
+    positional: t.Optional[str] = None
+    params: t.Dict[str, t.List[str]] = field(default_factory=dict)
+
+    def keys(self) -> t.Iterator[str]:
+        """Iterate over parameter keys."""
+        yield from self.params
+
+    def get_single(self, key: str) -> t.Union[str, None]:
+        """Get a single-value parameter. Returns None if key is absent or has multiple values."""
+        values = self.params.get(key)
+        if values is None:
+            return None
+        if len(values) != 1:
+            return None
+        return values[0]
+
+    def get_multi(self, key: str) -> t.Optional[t.List[str]]:
+        """Get a multi-value parameter. Returns None if key is absent."""
+        return self.params.get(key)
+
+    def __str__(self) -> str:
+        scope = self.prefix
+
+        if self.positional is not None:
+            scope += ':' + _normalize_uri_component(_encode_component(self.positional))
+
+        if self.params:
+            # Build query string preserving multi-value params
+            pairs: t.List[t.Tuple[str, str]] = []
+            for key, values in self.params.items():
+                for val in values:
+                    pairs.append((key, val))
+            scope += '?' + _normalize_uri_component(urlencode(pairs))
+
+        return scope
+
+    @classmethod
+    def from_string(cls, scope_value: str) -> 'ScopeStringSyntax':
+        """Parse a scope string into its components."""
+        param_idx = scope_value.find('?')
+        colon_idx = scope_value.find(':')
+        prefix_end = _min_idx(param_idx, colon_idx)
+
+        # No param or positional
+        if prefix_end == -1:
+            return cls(prefix=scope_value)
+
+        prefix = scope_value[:prefix_end]
+
+        # Parse positional parameter if present
+        positional: t.Optional[str] = None
+        if colon_idx != -1:
+            if param_idx == -1:
+                positional = unquote(scope_value[colon_idx + 1 :])
+            elif colon_idx < param_idx:
+                positional = unquote(scope_value[colon_idx + 1 : param_idx])
+            # else: colon is inside query string, no positional
+
+        # Parse query string if present and non-empty
+        params: t.Dict[str, t.List[str]] = {}
+        if param_idx != -1 and param_idx < len(scope_value) - 1:
+            params = parse_qs(scope_value[param_idx + 1 :], keep_blank_values=False)
+
+        return cls(prefix=prefix, positional=positional, params=params)
+
+
+def _min_idx(a: int, b: int) -> int:
+    """Return the smaller non-negative index, or -1 if both are -1."""
+    if a == -1:
+        return b
+    if b == -1:
+        return a
+    return min(a, b)
+
+
+# Characters that encodeURIComponent does NOT encode (besides alphanumeric).
+_UNRESERVED_CHARS = frozenset(('-', '_', '.', '!', '~', '*', "'", '(', ')'))
+
+# Additional characters allowed in scope strings without percent-encoding.
+_ALLOWED_SCOPE_CHARS = frozenset(':+,@/%')
+
+
+def _encode_component(value: str) -> str:
+    """Percent-encode a string for use in a scope, keeping allowed chars unencoded.
+
+    Mirrors JS ``encodeURIComponent`` which preserves ``A-Z a-z 0-9 - _ . ! ~ * ' ( )``
+    plus the additional scope-allowed chars (``:``, ``/``, ``+``, etc.).
+    """
+    result: t.List[str] = []
+    for ch in value:
+        if ch.isalnum() or ch in _UNRESERVED_CHARS or ch in _ALLOWED_SCOPE_CHARS:
+            result.append(ch)
+        else:
+            result.append('%{:02X}'.format(ord(ch)))
+    return ''.join(result)
+
+
+# Characters that should be decoded from percent-encoding in scope strings.
+# Union of scope-allowed chars and JS encodeURIComponent unreserved chars.
+_NORMALIZABLE_CHARS = _ALLOWED_SCOPE_CHARS | _UNRESERVED_CHARS
+
+
+def _normalize_uri_component(value: str) -> str:
+    """Decode percent-encoded chars that are allowed unencoded in scope strings."""
+    result: t.List[str] = []
+    i = 0
+    end = len(value)
+    while i < end:
+        if value[i] == '%' and i + 2 < end:
+            encoded = value[i : i + 3]
+            try:
+                decoded_char = chr(int(encoded[1:3], 16))
+            except ValueError:
+                result.append(value[i])
+                i += 1
+                continue
+            if decoded_char in _NORMALIZABLE_CHARS:
+                result.append(decoded_char)
+                i += 3
+            else:
+                result.append(encoded.upper())
+                i += 3
+        else:
+            result.append(value[i])
+            i += 1
+    return ''.join(result)

--- a/packages/atproto_oauth/scopes/_syntax.py
+++ b/packages/atproto_oauth/scopes/_syntax.py
@@ -5,8 +5,8 @@ into structured parts.
 
 Examples::
 
-    ScopeStringSyntax.from_string("repo:fm.plyr.track?action=create")
-    # -> prefix="repo", positional="fm.plyr.track", params={"action": ["create"]}
+    ScopeStringSyntax.from_string("repo:com.example.record?action=create")
+    # -> prefix="repo", positional="com.example.record", params={"action": ["create"]}
 
     ScopeStringSyntax.from_string("repo?collection=a.b.c&collection=d.e.f")
     # -> prefix="repo", positional=None, params={"collection": ["a.b.c", "d.e.f"]}

--- a/packages/atproto_oauth/scopes/exceptions.py
+++ b/packages/atproto_oauth/scopes/exceptions.py
@@ -1,0 +1,11 @@
+"""Scope-specific exceptions."""
+
+from atproto_oauth.exceptions import OAuthError
+
+
+class ScopeMissingError(OAuthError):
+    """Raised when a required scope is missing."""
+
+    def __init__(self, scope: str) -> None:
+        self.scope = scope
+        super().__init__(f'Missing required scope "{scope}"')

--- a/packages/atproto_oauth/scopes/permissions.py
+++ b/packages/atproto_oauth/scopes/permissions.py
@@ -1,0 +1,432 @@
+"""Permission types for ATProto OAuth scopes.
+
+Provides frozen dataclasses for each of the 6 scope resource types:
+``repo``, ``blob``, ``rpc``, ``account``, ``identity``, and ``include``.
+"""
+
+import re
+import typing as t
+from dataclasses import dataclass
+
+from atproto_core.nsid import validate_nsid
+
+from atproto_oauth.scopes._mime import is_accept, matches_any_accept
+from atproto_oauth.scopes._parser import ParamSchema, Parser
+from atproto_oauth.scopes._syntax import ScopeStringSyntax
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DID_RE = re.compile(
+    r'^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._%-]'
+    r'(?:#[a-zA-Z0-9._%-]+)?$'
+)
+
+
+def _is_nsid(value: str) -> bool:
+    """Validate an NSID using atproto_core."""
+    return validate_nsid(value, soft_fail=True)
+
+
+def _is_nsid_or_wildcard(value: str) -> bool:
+    return value == '*' or _is_nsid(value)
+
+
+def _is_atproto_audience(value: str) -> bool:
+    """Validate a DID or ``did:web:host#service_id`` audience string."""
+    if value == '*':
+        return True
+    return bool(_DID_RE.match(value))
+
+
+def _known_values_validator(values: t.FrozenSet[str]) -> t.Callable[[str], bool]:
+    return lambda v: v in values
+
+
+def _is_scope_string_for(value: str, prefix: str) -> bool:
+    """Check if a scope string starts with the given prefix."""
+    if len(value) > len(prefix):
+        next_char = value[len(prefix)]
+        if next_char not in (':', '?'):
+            return False
+        return value.startswith(prefix)
+    return value == prefix
+
+
+# ---------------------------------------------------------------------------
+# RepoPermission
+# ---------------------------------------------------------------------------
+
+REPO_ACTIONS: t.Tuple[str, ...] = ('create', 'update', 'delete')
+_is_repo_action = _known_values_validator(frozenset(REPO_ACTIONS))
+
+_repo_parser = Parser(
+    'repo',
+    {
+        'collection': ParamSchema(
+            multiple=True,
+            required=True,
+            validate=_is_nsid_or_wildcard,
+            normalize=lambda value: (['*'] if any(v == '*' for v in value) else sorted(set(value))),
+        ),
+        'action': ParamSchema(
+            multiple=True,
+            required=False,
+            validate=_is_repo_action,
+            default=list(REPO_ACTIONS),
+            normalize=lambda value: (
+                list(REPO_ACTIONS) if set(value) == set(REPO_ACTIONS) else [a for a in REPO_ACTIONS if a in value]
+            ),
+        ),
+    },
+    positional_name='collection',
+)
+
+
+@dataclass(frozen=True)
+class RepoPermission:
+    """Permission for repository record operations."""
+
+    collection: t.Tuple[str, ...]
+    action: t.Tuple[str, ...]
+
+    def matches(self, collection: str, action: str) -> bool:
+        return action in self.action and ('*' in self.collection or collection in self.collection)
+
+    def __str__(self) -> str:
+        return _repo_parser.format({'collection': list(self.collection), 'action': list(self.action)})
+
+    @classmethod
+    def from_string(cls, scope: str) -> t.Optional['RepoPermission']:
+        if not _is_scope_string_for(scope, 'repo'):
+            return None
+        syntax = ScopeStringSyntax.from_string(scope)
+        return cls.from_syntax(syntax)
+
+    @classmethod
+    def from_syntax(cls, syntax: ScopeStringSyntax) -> t.Optional['RepoPermission']:
+        result = _repo_parser.parse(syntax)
+        if result is None:
+            return None
+        return cls(
+            collection=tuple(result['collection']),
+            action=tuple(result['action']),
+        )
+
+    @staticmethod
+    def scope_needed_for(collection: str, action: str) -> str:
+        return _repo_parser.format(
+            {
+                'collection': [collection],
+                'action': [action],
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# BlobPermission
+# ---------------------------------------------------------------------------
+
+_DEFAULT_ACCEPT = ('*/*',)
+
+_blob_parser = Parser(
+    'blob',
+    {
+        'accept': ParamSchema(
+            multiple=True,
+            required=True,
+            validate=is_accept,
+            normalize=lambda value: (
+                list(_DEFAULT_ACCEPT)
+                if '*/*' in value
+                else sorted(set(_filter_non_redundant(v.lower() if isinstance(v, str) else v for v in value)))
+            ),
+        ),
+    },
+    positional_name='accept',
+)
+
+
+def _filter_non_redundant(values: t.Iterable[str]) -> t.List[str]:
+    """Remove MIME types that are redundant given wildcard patterns."""
+    items = list(values)
+    result: t.List[str] = []
+    for v in items:
+        if v.endswith('/*'):
+            result.append(v)
+        else:
+            base = v.split('/', 1)[0]
+            if f'{base}/*' not in items:
+                result.append(v)
+    return result
+
+
+@dataclass(frozen=True)
+class BlobPermission:
+    """Permission for blob uploads."""
+
+    accept: t.Tuple[str, ...]
+
+    def matches(self, mime: str) -> bool:
+        return matches_any_accept(self.accept, mime)
+
+    def __str__(self) -> str:
+        return _blob_parser.format({'accept': list(self.accept)})
+
+    @classmethod
+    def from_string(cls, scope: str) -> t.Optional['BlobPermission']:
+        if not _is_scope_string_for(scope, 'blob'):
+            return None
+        syntax = ScopeStringSyntax.from_string(scope)
+        return cls.from_syntax(syntax)
+
+    @classmethod
+    def from_syntax(cls, syntax: ScopeStringSyntax) -> t.Optional['BlobPermission']:
+        result = _blob_parser.parse(syntax)
+        if result is None:
+            return None
+        return cls(accept=tuple(result['accept']))
+
+    @staticmethod
+    def scope_needed_for(mime: str) -> str:
+        return _blob_parser.format({'accept': [mime]})
+
+
+# ---------------------------------------------------------------------------
+# RpcPermission
+# ---------------------------------------------------------------------------
+
+_rpc_parser = Parser(
+    'rpc',
+    {
+        'lxm': ParamSchema(
+            multiple=True,
+            required=True,
+            validate=_is_nsid_or_wildcard,
+            normalize=lambda value: (['*'] if len(value) > 1 and '*' in value else sorted(set(value))),
+        ),
+        'aud': ParamSchema(
+            multiple=False,
+            required=True,
+            validate=_is_atproto_audience,
+        ),
+    },
+    positional_name='lxm',
+)
+
+
+@dataclass(frozen=True)
+class RpcPermission:
+    """Permission for RPC (XRPC) method calls."""
+
+    aud: str
+    lxm: t.Tuple[str, ...]
+
+    def matches(self, lxm: str, aud: str) -> bool:
+        return (self.aud == '*' or self.aud == aud) and ('*' in self.lxm or lxm in self.lxm)
+
+    def __str__(self) -> str:
+        return _rpc_parser.format({'lxm': list(self.lxm), 'aud': self.aud})
+
+    @classmethod
+    def from_string(cls, scope: str) -> t.Optional['RpcPermission']:
+        if not _is_scope_string_for(scope, 'rpc'):
+            return None
+        syntax = ScopeStringSyntax.from_string(scope)
+        return cls.from_syntax(syntax)
+
+    @classmethod
+    def from_syntax(cls, syntax: ScopeStringSyntax) -> t.Optional['RpcPermission']:
+        result = _rpc_parser.parse(syntax)
+        if result is None:
+            return None
+        # rpc:*?aud=* is forbidden (too broad)
+        if result['aud'] == '*' and '*' in result['lxm']:
+            return None
+        return cls(aud=result['aud'], lxm=tuple(result['lxm']))
+
+    @staticmethod
+    def scope_needed_for(lxm: str, aud: str) -> str:
+        return _rpc_parser.format({'lxm': [lxm], 'aud': aud})
+
+
+# ---------------------------------------------------------------------------
+# AccountPermission
+# ---------------------------------------------------------------------------
+
+ACCOUNT_ATTRIBUTES: t.Tuple[str, ...] = ('email', 'repo', 'status')
+ACCOUNT_ACTIONS: t.Tuple[str, ...] = ('read', 'manage')
+
+_account_parser = Parser(
+    'account',
+    {
+        'attr': ParamSchema(
+            multiple=False,
+            required=True,
+            validate=_known_values_validator(frozenset(ACCOUNT_ATTRIBUTES)),
+        ),
+        'action': ParamSchema(
+            multiple=True,
+            required=False,
+            validate=_known_values_validator(frozenset(ACCOUNT_ACTIONS)),
+            default=['read'],
+        ),
+    },
+    positional_name='attr',
+)
+
+
+@dataclass(frozen=True)
+class AccountPermission:
+    """Permission for account attribute access."""
+
+    attr: str
+    action: t.Tuple[str, ...]
+
+    def matches(self, attr: str, action: str) -> bool:
+        return self.attr == attr and ('manage' in self.action or action in self.action)
+
+    def __str__(self) -> str:
+        return _account_parser.format({'attr': self.attr, 'action': list(self.action)})
+
+    @classmethod
+    def from_string(cls, scope: str) -> t.Optional['AccountPermission']:
+        if not _is_scope_string_for(scope, 'account'):
+            return None
+        syntax = ScopeStringSyntax.from_string(scope)
+        return cls.from_syntax(syntax)
+
+    @classmethod
+    def from_syntax(cls, syntax: ScopeStringSyntax) -> t.Optional['AccountPermission']:
+        result = _account_parser.parse(syntax)
+        if result is None:
+            return None
+        return cls(attr=result['attr'], action=tuple(result['action']))
+
+    @staticmethod
+    def scope_needed_for(attr: str, action: str) -> str:
+        return _account_parser.format({'attr': attr, 'action': [action]})
+
+
+# ---------------------------------------------------------------------------
+# IdentityPermission
+# ---------------------------------------------------------------------------
+
+IDENTITY_ATTRIBUTES: t.Tuple[str, ...] = ('handle', '*')
+
+_identity_parser = Parser(
+    'identity',
+    {
+        'attr': ParamSchema(
+            multiple=False,
+            required=True,
+            validate=_known_values_validator(frozenset(IDENTITY_ATTRIBUTES)),
+        ),
+    },
+    positional_name='attr',
+)
+
+
+@dataclass(frozen=True)
+class IdentityPermission:
+    """Permission for identity operations."""
+
+    attr: str
+
+    def matches(self, attr: str) -> bool:
+        return self.attr == '*' or self.attr == attr
+
+    def __str__(self) -> str:
+        return _identity_parser.format({'attr': self.attr})
+
+    @classmethod
+    def from_string(cls, scope: str) -> t.Optional['IdentityPermission']:
+        if not _is_scope_string_for(scope, 'identity'):
+            return None
+        syntax = ScopeStringSyntax.from_string(scope)
+        return cls.from_syntax(syntax)
+
+    @classmethod
+    def from_syntax(cls, syntax: ScopeStringSyntax) -> t.Optional['IdentityPermission']:
+        result = _identity_parser.parse(syntax)
+        if result is None:
+            return None
+        return cls(attr=result['attr'])
+
+    @staticmethod
+    def scope_needed_for(attr: str) -> str:
+        return _identity_parser.format({'attr': attr})
+
+
+# ---------------------------------------------------------------------------
+# IncludeScope
+# ---------------------------------------------------------------------------
+
+_include_parser = Parser(
+    'include',
+    {
+        'nsid': ParamSchema(
+            multiple=False,
+            required=True,
+            validate=_is_nsid,
+        ),
+        'aud': ParamSchema(
+            multiple=False,
+            required=False,
+            validate=_is_atproto_audience,
+        ),
+    },
+    positional_name='nsid',
+)
+
+
+@dataclass(frozen=True)
+class IncludeScope:
+    """An ``include:`` scope that references a lexicon permission set.
+
+    Not a permission itself — it resolves via a lexicon definition to produce
+    :class:`RepoPermission` and/or :class:`RpcPermission` instances.
+    """
+
+    nsid: str
+    aud: t.Optional[str] = None
+
+    def __str__(self) -> str:
+        values: t.Dict[str, t.Any] = {'nsid': self.nsid}
+        if self.aud is not None:
+            values['aud'] = self.aud
+        return _include_parser.format(values)
+
+    def is_parent_authority_of(self, other_nsid: str) -> bool:
+        """Check if ``other_nsid`` is in the same namespace authority.
+
+        The namespace authority is everything before the last ``.`` segment of
+        ``self.nsid``.  ``other_nsid`` must start with that same prefix.
+        """
+        if other_nsid == '*':
+            return False
+
+        group_prefix_end = self.nsid.rfind('.')
+        if group_prefix_end == -1:
+            raise TypeError('Dot character (".") missing from lexicon NSID')
+
+        if group_prefix_end >= len(other_nsid) - 1:
+            return False
+
+        # Compare char-by-char up to and including the dot
+        return self.nsid[: group_prefix_end + 1] == other_nsid[: group_prefix_end + 1]
+
+    @classmethod
+    def from_string(cls, scope: str) -> t.Optional['IncludeScope']:
+        if not _is_scope_string_for(scope, 'include'):
+            return None
+        syntax = ScopeStringSyntax.from_string(scope)
+        return cls.from_syntax(syntax)
+
+    @classmethod
+    def from_syntax(cls, syntax: ScopeStringSyntax) -> t.Optional['IncludeScope']:
+        result = _include_parser.parse(syntax)
+        if result is None:
+            return None
+        return cls(nsid=result['nsid'], aud=result.get('aud'))

--- a/packages/atproto_oauth/scopes/scope_permissions.py
+++ b/packages/atproto_oauth/scopes/scope_permissions.py
@@ -1,0 +1,61 @@
+"""Typed facade for scope permission checking."""
+
+import typing as t
+
+from atproto_oauth.scopes.exceptions import ScopeMissingError
+from atproto_oauth.scopes.permissions import (
+    AccountPermission,
+    BlobPermission,
+    IdentityPermission,
+    RepoPermission,
+    RpcPermission,
+)
+from atproto_oauth.scopes.scopes_set import ScopesSet
+
+
+class ScopePermissions:
+    """Typed permission checker wrapping a :class:`ScopesSet`.
+
+    Example::
+
+        perms = ScopePermissions("atproto repo:fm.plyr.track blob:*/*")
+        perms.allows_repo(collection='fm.plyr.track', action='create')  # True
+    """
+
+    def __init__(self, scope: t.Optional[str] = None) -> None:
+        self.scopes = ScopesSet.from_string(scope)
+
+    def allows_repo(self, collection: str, action: str) -> bool:
+        return self.scopes.matches('repo', collection=collection, action=action)
+
+    def assert_repo(self, collection: str, action: str) -> None:
+        if not self.allows_repo(collection, action):
+            raise ScopeMissingError(RepoPermission.scope_needed_for(collection, action))
+
+    def allows_blob(self, mime: str) -> bool:
+        return self.scopes.matches('blob', mime=mime)
+
+    def assert_blob(self, mime: str) -> None:
+        if not self.allows_blob(mime):
+            raise ScopeMissingError(BlobPermission.scope_needed_for(mime))
+
+    def allows_rpc(self, lxm: str, aud: str) -> bool:
+        return self.scopes.matches('rpc', lxm=lxm, aud=aud)
+
+    def assert_rpc(self, lxm: str, aud: str) -> None:
+        if not self.allows_rpc(lxm, aud):
+            raise ScopeMissingError(RpcPermission.scope_needed_for(lxm, aud))
+
+    def allows_account(self, attr: str, action: str) -> bool:
+        return self.scopes.matches('account', attr=attr, action=action)
+
+    def assert_account(self, attr: str, action: str) -> None:
+        if not self.allows_account(attr, action):
+            raise ScopeMissingError(AccountPermission.scope_needed_for(attr, action))
+
+    def allows_identity(self, attr: str) -> bool:
+        return self.scopes.matches('identity', attr=attr)
+
+    def assert_identity(self, attr: str) -> None:
+        if not self.allows_identity(attr):
+            raise ScopeMissingError(IdentityPermission.scope_needed_for(attr))

--- a/packages/atproto_oauth/scopes/scope_permissions.py
+++ b/packages/atproto_oauth/scopes/scope_permissions.py
@@ -18,8 +18,8 @@ class ScopePermissions:
 
     Example::
 
-        perms = ScopePermissions("atproto repo:fm.plyr.track blob:*/*")
-        perms.allows_repo(collection='fm.plyr.track', action='create')  # True
+        perms = ScopePermissions("atproto repo:com.example.record blob:*/*")
+        perms.allows_repo(collection='com.example.record', action='create')  # True
     """
 
     def __init__(self, scope: t.Optional[str] = None) -> None:

--- a/packages/atproto_oauth/scopes/scopes_set.py
+++ b/packages/atproto_oauth/scopes/scopes_set.py
@@ -1,0 +1,127 @@
+"""ScopesSet — container for parsed OAuth scope strings."""
+
+import typing as t
+
+from atproto_oauth.scopes.exceptions import ScopeMissingError
+from atproto_oauth.scopes.permissions import (
+    AccountPermission,
+    BlobPermission,
+    IdentityPermission,
+    RepoPermission,
+    RpcPermission,
+)
+
+
+def _parse_permission(
+    resource: str, scope: str
+) -> t.Union[RepoPermission, BlobPermission, RpcPermission, AccountPermission, IdentityPermission, None]:
+    """Try to parse a scope string as the given resource type."""
+    if resource == 'repo':
+        return RepoPermission.from_string(scope)
+    if resource == 'blob':
+        return BlobPermission.from_string(scope)
+    if resource == 'rpc':
+        return RpcPermission.from_string(scope)
+    if resource == 'account':
+        return AccountPermission.from_string(scope)
+    if resource == 'identity':
+        return IdentityPermission.from_string(scope)
+    return None
+
+
+def _scope_needed_for(resource: str, **kwargs: t.Any) -> str:
+    """Generate the scope string needed for a permission check."""
+    if resource == 'repo':
+        return RepoPermission.scope_needed_for(**kwargs)
+    if resource == 'blob':
+        return BlobPermission.scope_needed_for(**kwargs)
+    if resource == 'rpc':
+        return RpcPermission.scope_needed_for(**kwargs)
+    if resource == 'account':
+        return AccountPermission.scope_needed_for(**kwargs)
+    if resource == 'identity':
+        return IdentityPermission.scope_needed_for(**kwargs)
+    raise TypeError(f'Unknown resource: {resource}')
+
+
+class ScopesSet:
+    """A set of OAuth scope strings with permission matching.
+
+    Example::
+
+        scopes = ScopesSet.from_string("atproto repo:fm.plyr.track blob:*/*")
+        scopes.matches('repo', collection='fm.plyr.track', action='create')  # True
+        scopes.matches('blob', mime='image/png')  # True
+    """
+
+    def __init__(self, scopes: t.Optional[t.Iterable[str]] = None) -> None:
+        self._scopes: t.Set[str] = set(scopes) if scopes else set()
+
+    @classmethod
+    def from_string(cls, scope_string: t.Optional[str] = None) -> 'ScopesSet':
+        """Parse a space-separated scope string."""
+        if not scope_string:
+            return cls()
+        return cls(scope_string.split())
+
+    def has(self, scope: str) -> bool:
+        """Check if an exact scope string is in the set."""
+        return scope in self._scopes
+
+    def add(self, scope: str) -> None:
+        """Add a scope string to the set."""
+        self._scopes.add(scope)
+
+    def discard(self, scope: str) -> None:
+        """Remove a scope string if present."""
+        self._scopes.discard(scope)
+
+    @property
+    def size(self) -> int:
+        return len(self._scopes)
+
+    def matches(self, resource: str, **kwargs: t.Any) -> bool:
+        """Check if any scope in the set grants the requested permission.
+
+        Args:
+            resource: The resource type (``repo``, ``blob``, ``rpc``, ``account``, ``identity``).
+            **kwargs: Permission-specific parameters passed to ``matches()``.
+
+        Returns:
+            True if any scope grants the permission.
+        """
+        for scope in self._scopes:
+            perm = _parse_permission(resource, scope)
+            if perm is not None:
+                type_map = {
+                    'repo': RepoPermission,
+                    'blob': BlobPermission,
+                    'rpc': RpcPermission,
+                    'account': AccountPermission,
+                    'identity': IdentityPermission,
+                }
+                expected = type_map.get(resource)
+                if expected and isinstance(perm, expected) and perm.matches(**kwargs):
+                    return True
+        return False
+
+    def assert_matches(self, resource: str, **kwargs: t.Any) -> None:
+        """Assert that a scope grants the requested permission.
+
+        Raises :class:`~atproto_oauth.scopes.exceptions.ScopeMissingError` if not.
+        """
+        if not self.matches(resource, **kwargs):
+            scope = _scope_needed_for(resource, **kwargs)
+            raise ScopeMissingError(scope)
+
+    def __iter__(self) -> t.Iterator[str]:
+        return iter(self._scopes)
+
+    def __len__(self) -> int:
+        return len(self._scopes)
+
+    def __contains__(self, item: str) -> bool:
+        return item in self._scopes
+
+    def __repr__(self) -> str:
+        return f'ScopesSet({self._scopes!r})'

--- a/packages/atproto_oauth/scopes/scopes_set.py
+++ b/packages/atproto_oauth/scopes/scopes_set.py
@@ -49,8 +49,8 @@ class ScopesSet:
 
     Example::
 
-        scopes = ScopesSet.from_string("atproto repo:fm.plyr.track blob:*/*")
-        scopes.matches('repo', collection='fm.plyr.track', action='create')  # True
+        scopes = ScopesSet.from_string("atproto repo:com.example.record blob:*/*")
+        scopes.matches('repo', collection='com.example.record', action='create')  # True
         scopes.matches('blob', mime='image/png')  # True
     """
 

--- a/packages/atproto_oauth/scopes/transition.py
+++ b/packages/atproto_oauth/scopes/transition.py
@@ -1,0 +1,54 @@
+"""Legacy transition scope handling.
+
+Extends :class:`ScopePermissions` to handle ``transition:generic``,
+``transition:chat.bsky``, and ``transition:email`` scopes.
+"""
+
+from atproto_oauth.scopes.scope_permissions import ScopePermissions
+
+
+class ScopePermissionsTransition(ScopePermissions):
+    """Permission checker with transition scope support.
+
+    Transition scopes are legacy grants from the pre-scoped OAuth era:
+
+    - ``transition:generic``: all repo, all blob, all non-chat.bsky RPC
+    - ``transition:chat.bsky``: all chat.bsky.* RPC methods
+    - ``transition:email``: read access to account email
+    """
+
+    @property
+    def has_transition_generic(self) -> bool:
+        return self.scopes.has('transition:generic')
+
+    @property
+    def has_transition_email(self) -> bool:
+        return self.scopes.has('transition:email')
+
+    @property
+    def has_transition_chat_bsky(self) -> bool:
+        return self.scopes.has('transition:chat.bsky')
+
+    def allows_account(self, attr: str, action: str) -> bool:
+        if attr == 'email' and action == 'read' and self.has_transition_email:
+            return True
+        return super().allows_account(attr, action)
+
+    def allows_blob(self, mime: str) -> bool:
+        if self.has_transition_generic:
+            return True
+        return super().allows_blob(mime)
+
+    def allows_repo(self, collection: str, action: str) -> bool:
+        if self.has_transition_generic:
+            return True
+        return super().allows_repo(collection, action)
+
+    def allows_rpc(self, lxm: str, aud: str) -> bool:
+        if self.has_transition_generic and lxm == '*':
+            return True
+        if self.has_transition_generic and not lxm.startswith('chat.bsky.'):
+            return True
+        if self.has_transition_chat_bsky and lxm.startswith('chat.bsky.'):
+            return True
+        return super().allows_rpc(lxm, aud)

--- a/packages/atproto_oauth/security.py
+++ b/packages/atproto_oauth/security.py
@@ -1,0 +1,186 @@
+"""Security utilities for OAuth implementation."""
+
+import typing as t
+from urllib.parse import urlparse
+
+import httpx
+
+# Hardened HTTP client configuration
+DEFAULT_TIMEOUT = 5.0
+MAX_REDIRECTS = 3
+ALLOWED_SCHEMES = {'https', 'http'}  # http only for localhost
+BLOCKED_HOSTS = {
+    '0.0.0.0',
+    '127.0.0.1',
+    'localhost',
+    '::1',
+    '169.254.169.254',  # AWS metadata
+    'metadata.google.internal',  # GCP metadata
+}
+
+
+def is_safe_url(url: str, allow_localhost: bool = False) -> bool:
+    """Validate URL for security (SSRF protection).
+
+    Args:
+        url: URL to validate.
+        allow_localhost: Whether to allow localhost URLs.
+
+    Returns:
+        True if URL is safe to use.
+    """
+    try:
+        parsed = urlparse(url)
+
+        # Check scheme
+        if parsed.scheme not in ALLOWED_SCHEMES:
+            return False
+
+        # For http, only allow if allow_localhost and is actually localhost
+        if parsed.scheme == 'http':
+            if not allow_localhost:
+                return False
+            if parsed.hostname not in ('localhost', '127.0.0.1', '::1'):
+                return False
+
+        # Check for blocked hosts
+        if parsed.hostname in BLOCKED_HOSTS and not allow_localhost:
+            return False
+
+        # Check for IP addresses in private ranges (basic check)
+        if parsed.hostname:
+            # Block obvious private IPs
+            if parsed.hostname.startswith('10.'):
+                return False
+            if parsed.hostname.startswith('172.') and 16 <= int(parsed.hostname.split('.')[1]) <= 31:
+                return False
+            if parsed.hostname.startswith('192.168.'):
+                return False
+
+        return True
+    except Exception:
+        return False
+
+
+def get_hardened_client(
+    timeout: float = DEFAULT_TIMEOUT,
+    max_redirects: int = MAX_REDIRECTS,
+) -> httpx.Client:
+    """Create hardened HTTP client with security settings.
+
+    Args:
+        timeout: Request timeout in seconds.
+        max_redirects: Maximum number of redirects to follow.
+
+    Returns:
+        Configured httpx.Client.
+    """
+    return httpx.Client(
+        timeout=timeout,
+        follow_redirects=True,
+        max_redirects=max_redirects,
+        limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
+    )
+
+
+def get_hardened_async_client(
+    timeout: float = DEFAULT_TIMEOUT,
+    max_redirects: int = MAX_REDIRECTS,
+) -> httpx.AsyncClient:
+    """Create hardened async HTTP client with security settings.
+
+    Args:
+        timeout: Request timeout in seconds.
+        max_redirects: Maximum number of redirects to follow.
+
+    Returns:
+        Configured httpx.AsyncClient.
+    """
+    return httpx.AsyncClient(
+        timeout=timeout,
+        follow_redirects=True,
+        max_redirects=max_redirects,
+        limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
+    )
+
+
+def validate_authserver_metadata(metadata: t.Dict[str, t.Any], fetch_url: str) -> None:
+    """Validate authorization server metadata against ATProto requirements.
+
+    Args:
+        metadata: Metadata dictionary from server.
+        fetch_url: URL where metadata was fetched from.
+
+    Raises:
+        ValueError: If metadata doesn't meet requirements.
+    """
+    issuer_url = urlparse(metadata['issuer'])
+    fetch_parsed = urlparse(fetch_url)
+
+    # Issuer must match fetch URL host
+    if issuer_url.hostname != fetch_parsed.hostname:
+        raise ValueError(f'Issuer hostname mismatch: {issuer_url.hostname} != {fetch_parsed.hostname}')
+
+    # Issuer must be HTTPS with no path/params/fragment
+    if issuer_url.scheme != 'https':
+        raise ValueError(f'Issuer must be HTTPS: {issuer_url.scheme}')
+    if issuer_url.port is not None:
+        raise ValueError(f'Issuer must not have explicit port: {issuer_url.port}')
+    if issuer_url.path not in ('', '/'):
+        raise ValueError(f'Issuer must not have path: {issuer_url.path}')
+    if issuer_url.params or issuer_url.fragment:
+        raise ValueError('Issuer must not have params or fragment')
+
+    # Check required grant types and methods
+    required_checks = [
+        ('code' in metadata.get('response_types_supported', []), 'response_types_supported must include "code"'),
+        (
+            'authorization_code' in metadata.get('grant_types_supported', []),
+            'grant_types_supported must include "authorization_code"',
+        ),
+        (
+            'refresh_token' in metadata.get('grant_types_supported', []),
+            'grant_types_supported must include "refresh_token"',
+        ),
+        (
+            'S256' in metadata.get('code_challenge_methods_supported', []),
+            'code_challenge_methods_supported must include "S256"',
+        ),
+        (
+            'none' in metadata.get('token_endpoint_auth_methods_supported', []),
+            'token_endpoint_auth_methods_supported must include "none"',
+        ),
+        (
+            'private_key_jwt' in metadata.get('token_endpoint_auth_methods_supported', []),
+            'token_endpoint_auth_methods_supported must include "private_key_jwt"',
+        ),
+        (
+            'ES256' in metadata.get('token_endpoint_auth_signing_alg_values_supported', []),
+            'token_endpoint_auth_signing_alg_values_supported must include "ES256"',
+        ),
+        ('atproto' in metadata.get('scopes_supported', []), 'scopes_supported must include "atproto"'),
+        (
+            metadata.get('authorization_response_iss_parameter_supported') is True,
+            'authorization_response_iss_parameter_supported must be true',
+        ),
+        (
+            metadata.get('pushed_authorization_request_endpoint') is not None,
+            'pushed_authorization_request_endpoint is required',
+        ),
+        (
+            metadata.get('require_pushed_authorization_requests') is True,
+            'require_pushed_authorization_requests must be true',
+        ),
+        (
+            'ES256' in metadata.get('dpop_signing_alg_values_supported', []),
+            'dpop_signing_alg_values_supported must include "ES256"',
+        ),
+        (
+            metadata.get('client_id_metadata_document_supported') is True,
+            'client_id_metadata_document_supported must be true',
+        ),
+    ]
+
+    for check, error_msg in required_checks:
+        if not check:
+            raise ValueError(error_msg)

--- a/packages/atproto_oauth/stores/__init__.py
+++ b/packages/atproto_oauth/stores/__init__.py
@@ -1,0 +1,11 @@
+"""OAuth state and session stores."""
+
+from atproto_oauth.stores.base import SessionStore, StateStore
+from atproto_oauth.stores.memory import MemorySessionStore, MemoryStateStore
+
+__all__ = [
+    'MemorySessionStore',
+    'MemoryStateStore',
+    'SessionStore',
+    'StateStore',
+]

--- a/packages/atproto_oauth/stores/base.py
+++ b/packages/atproto_oauth/stores/base.py
@@ -1,0 +1,69 @@
+"""Abstract base classes for OAuth stores."""
+
+import typing as t
+from abc import ABC, abstractmethod
+
+if t.TYPE_CHECKING:
+    from atproto_oauth.models import OAuthSession, OAuthState
+
+
+class StateStore(ABC):
+    """Abstract store for OAuth state during authorization flow."""
+
+    @abstractmethod
+    async def save_state(self, state: 'OAuthState') -> None:
+        """Save OAuth state.
+
+        Args:
+            state: OAuth state object to save.
+        """
+
+    @abstractmethod
+    async def get_state(self, state_key: str) -> t.Optional['OAuthState']:
+        """Retrieve OAuth state by key.
+
+        Args:
+            state_key: State identifier.
+
+        Returns:
+            OAuth state object if found, None otherwise.
+        """
+
+    @abstractmethod
+    async def delete_state(self, state_key: str) -> None:
+        """Delete OAuth state by key.
+
+        Args:
+            state_key: State identifier.
+        """
+
+
+class SessionStore(ABC):
+    """Abstract store for OAuth sessions."""
+
+    @abstractmethod
+    async def save_session(self, session: 'OAuthSession') -> None:
+        """Save OAuth session.
+
+        Args:
+            session: OAuth session object to save.
+        """
+
+    @abstractmethod
+    async def get_session(self, did: str) -> t.Optional['OAuthSession']:
+        """Retrieve OAuth session by DID.
+
+        Args:
+            did: User DID.
+
+        Returns:
+            OAuth session object if found, None otherwise.
+        """
+
+    @abstractmethod
+    async def delete_session(self, did: str) -> None:
+        """Delete OAuth session by DID.
+
+        Args:
+            did: User DID.
+        """

--- a/packages/atproto_oauth/stores/memory.py
+++ b/packages/atproto_oauth/stores/memory.py
@@ -1,0 +1,71 @@
+"""In-memory OAuth stores for development."""
+
+import typing as t
+from datetime import datetime, timedelta, timezone
+
+from atproto_oauth.models import OAuthSession, OAuthState
+from atproto_oauth.stores.base import SessionStore, StateStore
+
+
+class MemoryStateStore(StateStore):
+    """In-memory OAuth state store.
+
+    Warning:
+        This store is not suitable for production use in multi-process
+        or distributed environments. Use a persistent store instead.
+    """
+
+    def __init__(self, state_ttl_seconds: int = 600) -> None:
+        """Initialize memory state store.
+
+        Args:
+            state_ttl_seconds: Time-to-live for state entries in seconds.
+        """
+        self._states: t.Dict[str, OAuthState] = {}
+        self._state_ttl = timedelta(seconds=state_ttl_seconds)
+
+    async def save_state(self, state: OAuthState) -> None:
+        """Save OAuth state."""
+        self._cleanup_expired_states()
+        self._states[state.state] = state
+
+    async def get_state(self, state_key: str) -> t.Optional[OAuthState]:
+        """Retrieve OAuth state by key."""
+        self._cleanup_expired_states()
+        return self._states.get(state_key)
+
+    async def delete_state(self, state_key: str) -> None:
+        """Delete OAuth state by key."""
+        self._states.pop(state_key, None)
+
+    def _cleanup_expired_states(self) -> None:
+        """Remove expired state entries."""
+        now = datetime.now(timezone.utc)
+        expired = [state_key for state_key, state in self._states.items() if (now - state.created_at) > self._state_ttl]
+        for state_key in expired:
+            del self._states[state_key]
+
+
+class MemorySessionStore(SessionStore):
+    """In-memory OAuth session store.
+
+    Warning:
+        This store is not suitable for production use in multi-process
+        or distributed environments. Use a persistent store instead.
+    """
+
+    def __init__(self) -> None:
+        """Initialize memory session store."""
+        self._sessions: t.Dict[str, OAuthSession] = {}
+
+    async def save_session(self, session: OAuthSession) -> None:
+        """Save OAuth session."""
+        self._sessions[session.did] = session
+
+    async def get_session(self, did: str) -> t.Optional[OAuthSession]:
+        """Retrieve OAuth session by DID."""
+        return self._sessions.get(did)
+
+    async def delete_session(self, did: str) -> None:
+        """Delete OAuth session by DID."""
+        self._sessions.pop(did, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ packages = [
     { include = "atproto_identity", from = "packages" },
     { include = "atproto_lexicon", from = "packages" },
     { include = "atproto_server", from = "packages" },
+    { include = "atproto_oauth", from = "packages" },
 ]
 version = "0.0.0" # This is a placeholder. Dynamic version from Git Tag will be used.
 
@@ -159,10 +160,13 @@ ignore = [
     "D105", "D104", "D100", "D107", "D103", "D415", # missing docstring
     "D101", "D102", # missing docstring in public class and method
 ]
-"tests/*.py" = ["D"]
+"tests/*.py" = ["D", "S105"]
 "docs/*.py" = ["T201", "INP001", "ERA001", "E501", "D"]
 "examples/*.py" = ["T201", "INP001", "ERA001", "D"]
 "packages/atproto/exceptions.py" = ["F403"]
+"packages/atproto_oauth/*.py" = [
+    "S105", "S104", "BLE001", "S110", "SIM105", "SIM102", "C901",
+]
 "packages/atproto_client/models/__init__.py" = ["F401", "F811"]
 "packages/atproto_client/models/*/*.py" = ["E501", "D401"]
 "packages/atproto_client/namespaces/async_ns.py" = ["E501", "D401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ ignore = [
     "D105", "D104", "D100", "D107", "D103", "D415", # missing docstring
     "D101", "D102", # missing docstring in public class and method
 ]
-"tests/*.py" = ["D", "S105"]
+"tests/*.py" = ["D", "S105", "S106"]
 "docs/*.py" = ["T201", "INP001", "ERA001", "E501", "D"]
 "examples/*.py" = ["T201", "INP001", "ERA001", "D"]
 "packages/atproto/exceptions.py" = ["F403"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,10 @@ ignore = [
 "packages/atproto_oauth/*.py" = [
     "S105", "S104", "BLE001", "S110", "SIM105", "SIM102", "C901",
 ]
+"packages/atproto_oauth/scopes/*.py" = [
+    "SIM103", "SIM108", "SIM110", "SIM118", # ported from TS reference; keep structure close
+    "C401", # set() with generator matches TS style
+]
 "packages/atproto_client/models/__init__.py" = ["E501", "F401", "F811"]
 "packages/atproto_client/models/*/*.py" = ["E501", "D401"]
 "packages/atproto_client/namespaces/async_ns.py" = ["E501", "D401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ packages = [
     { include = "atproto_identity", from = "packages" },
     { include = "atproto_lexicon", from = "packages" },
     { include = "atproto_server", from = "packages" },
+    { include = "atproto_oauth", from = "packages" },
 ]
 version = "0.0.0" # This is a placeholder. Dynamic version from Git Tag will be used.
 
@@ -159,10 +160,13 @@ ignore = [
     "D105", "D104", "D100", "D107", "D103", "D415", # missing docstring
     "D101", "D102", # missing docstring in public class and method
 ]
-"tests/*.py" = ["D"]
+"tests/*.py" = ["D", "S105"]
 "docs/*.py" = ["T201", "INP001", "ERA001", "E501", "D"]
 "examples/*.py" = ["T201", "INP001", "ERA001", "D"]
 "packages/atproto/exceptions.py" = ["F403"]
+"packages/atproto_oauth/*.py" = [
+    "S105", "S104", "BLE001", "S110", "SIM105", "SIM102", "C901",
+]
 "packages/atproto_client/models/__init__.py" = ["E501", "F401", "F811"]
 "packages/atproto_client/models/*/*.py" = ["E501", "D401"]
 "packages/atproto_client/namespaces/async_ns.py" = ["E501", "D401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,8 @@ packages = [
     { include = "atproto_firehose", from = "packages" },
     { include = "atproto_identity", from = "packages" },
     { include = "atproto_lexicon", from = "packages" },
-    { include = "atproto_server", from = "packages" },
     { include = "atproto_oauth", from = "packages" },
+    { include = "atproto_server", from = "packages" },
 ]
 version = "0.0.0" # This is a placeholder. Dynamic version from Git Tag will be used.
 

--- a/tests/test_oauth_client.py
+++ b/tests/test_oauth_client.py
@@ -1,0 +1,134 @@
+"""Tests for OAuth client implementation."""
+
+import typing as t
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from atproto_oauth import OAuthClient, PromptType
+from atproto_oauth.stores.memory import MemorySessionStore, MemoryStateStore
+
+
+@pytest.fixture
+def oauth_client() -> OAuthClient:
+    """Create an OAuth client for testing."""
+    return OAuthClient(
+        client_id='https://example.com/client-metadata.json',
+        redirect_uri='https://example.com/callback',
+        scope='atproto',
+        state_store=MemoryStateStore(),
+        session_store=MemorySessionStore(),
+    )
+
+
+def test_prompt_type_values() -> None:
+    """Test that PromptType includes all valid values."""
+    valid_prompts: list[PromptType] = ['login', 'select_account', 'consent', 'none']
+    assert len(valid_prompts) == 4
+
+
+def test_prompt_type_is_exported() -> None:
+    """Test that PromptType is exported from the package."""
+    from atproto_oauth import PromptType as ImportedPromptType
+
+    assert ImportedPromptType is PromptType
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('prompt', ['login', 'select_account', 'consent', 'none', None])
+async def test_prompt_passed_to_par_request(oauth_client: OAuthClient, prompt: t.Optional[str]) -> None:
+    """Test that prompt parameter flows through to _send_par_request."""
+    oauth_client._id_resolver.handle.resolve = AsyncMock(return_value='did:plc:test123')
+    oauth_client._id_resolver.did.resolve_atproto_data = AsyncMock(
+        return_value=MagicMock(handle='test.bsky.social', pds='https://pds.example.com')
+    )
+
+    captured_prompt: t.Optional[str] = None
+
+    async def mock_send_par(
+        authserver_meta: t.Any,
+        login_hint: str,
+        pkce_challenge: str,
+        dpop_key: t.Any,
+        state: str,
+        prompt: t.Optional[str] = None,
+    ) -> tuple[str, str]:
+        nonlocal captured_prompt
+        captured_prompt = prompt
+        return 'urn:ietf:params:oauth:request_uri:test', 'nonce123'
+
+    oauth_client._send_par_request = mock_send_par  # type: ignore[method-assign]
+
+    with (
+        patch(
+            'atproto_oauth.client.discover_authserver_from_pds_async',
+            new=AsyncMock(return_value='https://auth.example.com'),
+        ),
+        patch(
+            'atproto_oauth.client.fetch_authserver_metadata_async',
+            new=AsyncMock(
+                return_value=MagicMock(
+                    issuer='https://auth.example.com',
+                    authorization_endpoint='https://auth.example.com/authorize',
+                    pushed_authorization_request_endpoint='https://auth.example.com/par',
+                )
+            ),
+        ),
+    ):
+        await oauth_client.start_authorization('test.bsky.social', prompt=prompt)
+        assert captured_prompt == prompt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('prompt', 'expect_in_params'),
+    [
+        ('login', True),
+        ('select_account', True),
+        ('consent', True),
+        ('none', True),
+        (None, False),
+    ],
+)
+async def test_prompt_in_par_params(
+    oauth_client: OAuthClient,
+    prompt: t.Optional[str],
+    expect_in_params: bool,
+) -> None:
+    """Test that prompt is included in PAR params only when provided."""
+    authserver_meta = MagicMock(
+        issuer='https://auth.example.com',
+        pushed_authorization_request_endpoint='https://auth.example.com/par',
+    )
+
+    captured_params: dict[str, str] = {}
+
+    async def mock_make_token_request(
+        token_url: str,
+        params: dict[str, str],
+        dpop_key: t.Any,
+        dpop_nonce: str,
+        issuer: t.Optional[str] = None,
+    ) -> tuple[str, MagicMock]:
+        nonlocal captured_params
+        captured_params = params.copy()
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {'request_uri': 'urn:test:uri'}
+        return 'nonce', response
+
+    oauth_client._make_token_request = mock_make_token_request  # type: ignore[method-assign]
+
+    await oauth_client._send_par_request(
+        authserver_meta=authserver_meta,
+        login_hint='test.bsky.social',
+        pkce_challenge='challenge123',
+        dpop_key=MagicMock(),
+        state='state123',
+        prompt=prompt,
+    )
+
+    if expect_in_params:
+        assert 'prompt' in captured_params
+        assert captured_params['prompt'] == prompt
+    else:
+        assert 'prompt' not in captured_params

--- a/tests/test_oauth_client.py
+++ b/tests/test_oauth_client.py
@@ -176,13 +176,23 @@ async def test_handle_callback_sets_expires_at(oauth_client: OAuthClient) -> Non
 
     oauth_client._make_token_request = mock_make_token_request  # type: ignore[method-assign]
 
-    with patch(
-        'atproto_oauth.client.fetch_authserver_metadata_async',
-        new=AsyncMock(
-            return_value=MagicMock(
-                issuer='https://auth.example.com',
-                token_endpoint='https://auth.example.com/token',
-            )
+    # Mock the identity resolver for re-verification step
+    mock_atproto_data = MagicMock(pds='https://pds.example.com')
+    oauth_client._id_resolver.did.resolve_atproto_data = AsyncMock(return_value=mock_atproto_data)
+
+    with (
+        patch(
+            'atproto_oauth.client.fetch_authserver_metadata_async',
+            new=AsyncMock(
+                return_value=MagicMock(
+                    issuer='https://auth.example.com',
+                    token_endpoint='https://auth.example.com/token',
+                )
+            ),
+        ),
+        patch(
+            'atproto_oauth.client.discover_authserver_from_pds_async',
+            new=AsyncMock(return_value='https://auth.example.com'),
         ),
     ):
         before = datetime.now(timezone.utc)
@@ -235,13 +245,23 @@ async def test_handle_callback_no_expires_in(oauth_client: OAuthClient) -> None:
 
     oauth_client._make_token_request = mock_make_token_request  # type: ignore[method-assign]
 
-    with patch(
-        'atproto_oauth.client.fetch_authserver_metadata_async',
-        new=AsyncMock(
-            return_value=MagicMock(
-                issuer='https://auth.example.com',
-                token_endpoint='https://auth.example.com/token',
-            )
+    # Mock the identity resolver for re-verification step
+    mock_atproto_data = MagicMock(pds='https://pds.example.com')
+    oauth_client._id_resolver.did.resolve_atproto_data = AsyncMock(return_value=mock_atproto_data)
+
+    with (
+        patch(
+            'atproto_oauth.client.fetch_authserver_metadata_async',
+            new=AsyncMock(
+                return_value=MagicMock(
+                    issuer='https://auth.example.com',
+                    token_endpoint='https://auth.example.com/token',
+                )
+            ),
+        ),
+        patch(
+            'atproto_oauth.client.discover_authserver_from_pds_async',
+            new=AsyncMock(return_value='https://auth.example.com'),
         ),
     ):
         session = await oauth_client.handle_callback(

--- a/tests/test_oauth_client.py
+++ b/tests/test_oauth_client.py
@@ -1,10 +1,11 @@
 """Tests for OAuth client implementation."""
 
 import typing as t
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from atproto_oauth import OAuthClient, PromptType
+from atproto_oauth import OAuthClient, OAuthState, PromptType
 from atproto_oauth.stores.memory import MemorySessionStore, MemoryStateStore
 
 
@@ -132,3 +133,119 @@ async def test_prompt_in_par_params(
         assert captured_params['prompt'] == prompt
     else:
         assert 'prompt' not in captured_params
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_sets_expires_at(oauth_client: OAuthClient) -> None:
+    """Test that handle_callback computes expires_at from expires_in."""
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    dpop_key = ec.generate_private_key(ec.SECP256R1())
+
+    # Store a state so handle_callback can find it
+    state = OAuthState(
+        state='test-state',
+        pkce_verifier='verifier123',
+        redirect_uri='https://example.com/callback',
+        scope='atproto',
+        authserver_iss='https://auth.example.com',
+        dpop_private_key=dpop_key,
+        dpop_authserver_nonce='nonce',
+        did='did:plc:test123',
+        handle='test.bsky.social',
+        pds_url='https://pds.example.com',
+    )
+    await oauth_client.state_store.save_state(state)
+
+    token_response_data = {
+        'access_token': 'access-token-123',
+        'token_type': 'DPoP',
+        'scope': 'atproto',
+        'sub': 'did:plc:test123',
+        'refresh_token': 'refresh-token-123',
+        'expires_in': 3600,
+    }
+
+    async def mock_make_token_request(
+        token_url: str, params: dict, dpop_key: t.Any, dpop_nonce: str, issuer: t.Optional[str] = None
+    ) -> tuple[str, MagicMock]:
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = token_response_data
+        return 'nonce-updated', response
+
+    oauth_client._make_token_request = mock_make_token_request  # type: ignore[method-assign]
+
+    with patch(
+        'atproto_oauth.client.fetch_authserver_metadata_async',
+        new=AsyncMock(
+            return_value=MagicMock(
+                issuer='https://auth.example.com',
+                token_endpoint='https://auth.example.com/token',
+            )
+        ),
+    ):
+        before = datetime.now(timezone.utc)
+        session = await oauth_client.handle_callback(
+            code='auth-code-123', state='test-state', iss='https://auth.example.com'
+        )
+        after = datetime.now(timezone.utc)
+
+    assert session.expires_at is not None
+    expected_min = before + timedelta(seconds=3600)
+    expected_max = after + timedelta(seconds=3600)
+    assert expected_min <= session.expires_at <= expected_max
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_no_expires_in(oauth_client: OAuthClient) -> None:
+    """Test that expires_at is None when server omits expires_in."""
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    dpop_key = ec.generate_private_key(ec.SECP256R1())
+
+    state = OAuthState(
+        state='test-state-2',
+        pkce_verifier='verifier123',
+        redirect_uri='https://example.com/callback',
+        scope='atproto',
+        authserver_iss='https://auth.example.com',
+        dpop_private_key=dpop_key,
+        dpop_authserver_nonce='nonce',
+        did='did:plc:test123',
+        handle='test.bsky.social',
+        pds_url='https://pds.example.com',
+    )
+    await oauth_client.state_store.save_state(state)
+
+    token_response_data = {
+        'access_token': 'access-token-456',
+        'token_type': 'DPoP',
+        'scope': 'atproto',
+        'sub': 'did:plc:test123',
+    }
+
+    async def mock_make_token_request(
+        token_url: str, params: dict, dpop_key: t.Any, dpop_nonce: str, issuer: t.Optional[str] = None
+    ) -> tuple[str, MagicMock]:
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = token_response_data
+        return 'nonce-updated', response
+
+    oauth_client._make_token_request = mock_make_token_request  # type: ignore[method-assign]
+
+    with patch(
+        'atproto_oauth.client.fetch_authserver_metadata_async',
+        new=AsyncMock(
+            return_value=MagicMock(
+                issuer='https://auth.example.com',
+                token_endpoint='https://auth.example.com/token',
+            )
+        ),
+    ):
+        session = await oauth_client.handle_callback(
+            code='auth-code-456', state='test-state-2', iss='https://auth.example.com'
+        )
+
+    assert session.expires_at is None

--- a/tests/test_oauth_dpop.py
+++ b/tests/test_oauth_dpop.py
@@ -1,0 +1,239 @@
+"""Tests for DPoP implementation."""
+
+import json
+
+import httpx
+from atproto_oauth.dpop import DPoPManager
+
+
+def test_generate_keypair() -> None:
+    """Test generating DPoP keypair."""
+    key = DPoPManager.generate_keypair()
+    assert key is not None
+
+    # Verify it's an EC key
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    assert isinstance(key, ec.EllipticCurvePrivateKey)
+
+
+def test_create_proof() -> None:
+    """Test creating DPoP proof JWT."""
+    key = DPoPManager.generate_keypair()
+
+    proof = DPoPManager.create_proof(
+        method='GET',
+        url='https://example.com/api',
+        private_key=key,
+    )
+
+    # Verify JWT structure
+    assert isinstance(proof, str)
+    parts = proof.split('.')
+    assert len(parts) == 3  # header.payload.signature
+
+    # Decode and verify header
+    import base64
+
+    header_json = base64.urlsafe_b64decode(parts[0] + '==')
+    header = json.loads(header_json)
+
+    assert header['typ'] == 'dpop+jwt'
+    assert header['alg'] == 'ES256'
+    assert 'jwk' in header
+
+    # Decode and verify payload
+    payload_json = base64.urlsafe_b64decode(parts[1] + '==')
+    payload = json.loads(payload_json)
+
+    assert payload['htm'] == 'GET'
+    assert payload['htu'] == 'https://example.com/api'
+    assert 'jti' in payload
+    assert 'iat' in payload
+    assert 'exp' in payload
+
+
+def test_create_proof_with_nonce() -> None:
+    """Test creating DPoP proof with nonce."""
+    key = DPoPManager.generate_keypair()
+    nonce = 'test-nonce-123'
+
+    proof = DPoPManager.create_proof(
+        method='POST',
+        url='https://example.com/api',
+        private_key=key,
+        nonce=nonce,
+    )
+
+    # Decode payload and verify nonce
+    import base64
+
+    parts = proof.split('.')
+    payload_json = base64.urlsafe_b64decode(parts[1] + '==')
+    payload = json.loads(payload_json)
+
+    assert payload['nonce'] == nonce
+
+
+def test_create_proof_with_access_token() -> None:
+    """Test creating DPoP proof with access token hash."""
+    key = DPoPManager.generate_keypair()
+    access_token = 'test-access-token'
+
+    proof = DPoPManager.create_proof(
+        method='POST',
+        url='https://example.com/api',
+        private_key=key,
+        access_token=access_token,
+    )
+
+    # Decode payload and verify ath claim
+    import base64
+    import hashlib
+
+    parts = proof.split('.')
+    payload_json = base64.urlsafe_b64decode(parts[1] + '==')
+    payload = json.loads(payload_json)
+
+    assert 'ath' in payload
+
+    # Verify ath is correct hash
+    expected_hash = hashlib.sha256(access_token.encode('utf-8')).digest()
+    expected_ath = base64.urlsafe_b64encode(expected_hash).decode('utf-8').rstrip('=')
+    assert payload['ath'] == expected_ath
+
+
+def test_is_dpop_nonce_error() -> None:
+    """Test detecting DPoP nonce error responses."""
+    # Test with error in JSON body
+    response = httpx.Response(
+        status_code=401,
+        json={'error': 'use_dpop_nonce'},
+        headers={'DPoP-Nonce': 'new-nonce'},
+    )
+    assert DPoPManager.is_dpop_nonce_error(response)
+
+    # Test with error in WWW-Authenticate header
+    response = httpx.Response(
+        status_code=401,
+        headers={
+            'WWW-Authenticate': 'DPoP error="use_dpop_nonce"',
+            'DPoP-Nonce': 'new-nonce',
+        },
+    )
+    assert DPoPManager.is_dpop_nonce_error(response)
+
+    # Test normal response
+    response = httpx.Response(status_code=200, json={'success': True})
+    assert not DPoPManager.is_dpop_nonce_error(response)
+
+
+def test_extract_nonce_from_response() -> None:
+    """Test extracting DPoP nonce from response."""
+    response = httpx.Response(
+        status_code=401,
+        headers={'DPoP-Nonce': 'test-nonce-456'},
+    )
+
+    nonce = DPoPManager.extract_nonce_from_response(response)
+    assert nonce == 'test-nonce-456'
+
+    # Test response without nonce
+    response = httpx.Response(status_code=200)
+    nonce = DPoPManager.extract_nonce_from_response(response)
+    assert nonce is None
+
+
+def test_dpop_signature_format() -> None:
+    """Test that DPoP signature uses IEEE P1363 format (64 bytes for ES256)."""
+    key = DPoPManager.generate_keypair()
+
+    proof = DPoPManager.create_proof(
+        method='POST',
+        url='https://example.com/token',
+        private_key=key,
+    )
+
+    # Decode signature
+    import base64
+
+    parts = proof.split('.')
+    # Add padding if needed
+    signature_b64 = parts[2] + '=' * (4 - len(parts[2]) % 4)
+    signature_bytes = base64.urlsafe_b64decode(signature_b64)
+
+    # ES256 signature should be 64 bytes (32 for r, 32 for s)
+    assert len(signature_bytes) == 64, f'Signature length is {len(signature_bytes)}, expected 64'
+
+
+def test_dpop_htu_strips_query_and_fragment() -> None:
+    """Test that htu field strips query and fragment per RFC 9449."""
+    key = DPoPManager.generate_keypair()
+
+    # Test with query parameters
+    proof = DPoPManager.create_proof(
+        method='POST',
+        url='https://example.com/token?param=value&other=test',
+        private_key=key,
+    )
+
+    import base64
+
+    parts = proof.split('.')
+    payload_json = base64.urlsafe_b64decode(parts[1] + '==')
+    payload = json.loads(payload_json)
+
+    assert payload['htu'] == 'https://example.com/token'
+
+    # Test with fragment
+    proof = DPoPManager.create_proof(
+        method='GET',
+        url='https://example.com/api#section',
+        private_key=key,
+    )
+
+    parts = proof.split('.')
+    payload_json = base64.urlsafe_b64decode(parts[1] + '==')
+    payload = json.loads(payload_json)
+
+    assert payload['htu'] == 'https://example.com/api'
+
+    # Test with both query and fragment
+    proof = DPoPManager.create_proof(
+        method='GET',
+        url='https://example.com/api?foo=bar#section',
+        private_key=key,
+    )
+
+    parts = proof.split('.')
+    payload_json = base64.urlsafe_b64decode(parts[1] + '==')
+    payload = json.loads(payload_json)
+
+    assert payload['htu'] == 'https://example.com/api'
+
+
+def test_dpop_jwk_format() -> None:
+    """Test that JWK in header is properly formatted."""
+    key = DPoPManager.generate_keypair()
+
+    proof = DPoPManager.create_proof(
+        method='POST',
+        url='https://example.com/token',
+        private_key=key,
+    )
+
+    import base64
+
+    parts = proof.split('.')
+    header_json = base64.urlsafe_b64decode(parts[0] + '==')
+    header = json.loads(header_json)
+
+    jwk = header['jwk']
+
+    # Verify JWK structure
+    assert jwk['kty'] == 'EC'
+    assert jwk['crv'] == 'P-256'
+    assert 'x' in jwk
+    assert 'y' in jwk
+    # Must NOT contain private key
+    assert 'd' not in jwk

--- a/tests/test_oauth_pkce.py
+++ b/tests/test_oauth_pkce.py
@@ -1,0 +1,64 @@
+"""Tests for PKCE implementation."""
+
+import hashlib
+from base64 import urlsafe_b64encode
+
+import pytest
+from atproto_oauth.pkce import PKCEManager
+
+
+def test_generate_verifier_default_length() -> None:
+    """Test generating PKCE verifier with default length."""
+    verifier = PKCEManager.generate_verifier()
+    assert isinstance(verifier, str)
+    assert 43 <= len(verifier) <= 128
+
+
+def test_generate_verifier_custom_length() -> None:
+    """Test generating PKCE verifier with custom length."""
+    length = 64
+    verifier = PKCEManager.generate_verifier(length)
+    assert len(verifier) == length
+
+
+def test_generate_verifier_invalid_length() -> None:
+    """Test that invalid length raises error."""
+    with pytest.raises(ValueError, match='must be between 43 and 128'):
+        PKCEManager.generate_verifier(20)
+
+    with pytest.raises(ValueError, match='must be between 43 and 128'):
+        PKCEManager.generate_verifier(200)
+
+
+def test_generate_challenge() -> None:
+    """Test generating S256 challenge from verifier."""
+    verifier = 'test_verifier_123456789'
+    challenge = PKCEManager.generate_challenge(verifier)
+
+    # Verify it's base64url encoded SHA256
+    expected_digest = hashlib.sha256(verifier.encode('utf-8')).digest()
+    expected_challenge = urlsafe_b64encode(expected_digest).decode('utf-8').rstrip('=')
+
+    assert challenge == expected_challenge
+
+
+def test_generate_pair() -> None:
+    """Test generating verifier and challenge pair."""
+    verifier, challenge = PKCEManager.generate_pair()
+
+    # Verify verifier format
+    assert isinstance(verifier, str)
+    assert 43 <= len(verifier) <= 128
+
+    # Verify challenge matches verifier
+    expected_challenge = PKCEManager.generate_challenge(verifier)
+    assert challenge == expected_challenge
+
+
+def test_challenge_is_deterministic() -> None:
+    """Test that same verifier always produces same challenge."""
+    verifier = PKCEManager.generate_verifier()
+    challenge1 = PKCEManager.generate_challenge(verifier)
+    challenge2 = PKCEManager.generate_challenge(verifier)
+
+    assert challenge1 == challenge2

--- a/tests/test_oauth_scopes.py
+++ b/tests/test_oauth_scopes.py
@@ -1,0 +1,869 @@
+"""Tests for ATProto OAuth scope parsing library.
+
+Ported from the TypeScript reference implementation test suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+from atproto_oauth.client import _scopes_are_equivalent
+from atproto_oauth.scopes import (
+    AccountPermission,
+    BlobPermission,
+    IdentityPermission,
+    IncludeScope,
+    RepoPermission,
+    RpcPermission,
+    ScopeMissingError,
+    ScopePermissions,
+    ScopePermissionsTransition,
+    ScopesSet,
+)
+from atproto_oauth.scopes._mime import is_accept, is_mime, matches_accept, matches_any_accept
+from atproto_oauth.scopes._syntax import ScopeStringSyntax
+
+# ---------------------------------------------------------------------------
+# ScopeStringSyntax
+# ---------------------------------------------------------------------------
+
+
+class TestScopeStringSyntax:
+    """Tests for scope string tokenizer."""
+
+    @pytest.mark.parametrize(
+        'scope,prefix,positional,params',
+        [
+            ('my-res', 'my-res', None, {}),
+            ('my-res:my-pos', 'my-res', 'my-pos', {}),
+            ('my-res:', 'my-res', '', {}),
+            (
+                'my-res:foo?x=value&y=value-y',
+                'my-res',
+                'foo',
+                {'x': ['value'], 'y': ['value-y']},
+            ),
+            (
+                'my-res?x=value&y=value-y',
+                'my-res',
+                None,
+                {'x': ['value'], 'y': ['value-y']},
+            ),
+            (
+                'my-res?x=foo&x=bar&x=baz',
+                'my-res',
+                None,
+                {'x': ['foo', 'bar', 'baz']},
+            ),
+        ],
+    )
+    def test_parse_scope(
+        self,
+        scope: str,
+        prefix: str,
+        positional: str | None,
+        params: dict[str, list[str]],
+    ) -> None:
+        syntax = ScopeStringSyntax.from_string(scope)
+        assert syntax.prefix == prefix
+        assert syntax.positional == positional
+        assert syntax.params == params
+
+    def test_get_single_returns_none_for_absent(self) -> None:
+        syntax = ScopeStringSyntax.from_string('my-res')
+        assert syntax.get_single('nonexistent') is None
+
+    def test_get_multi_returns_none_for_absent(self) -> None:
+        syntax = ScopeStringSyntax.from_string('my-res')
+        assert syntax.get_multi('nonexistent') is None
+
+    def test_get_single_returns_none_for_multi_value(self) -> None:
+        syntax = ScopeStringSyntax.from_string('my-res?x=foo&x=bar')
+        assert syntax.get_single('x') is None
+
+    def test_get_multi_returns_values(self) -> None:
+        syntax = ScopeStringSyntax.from_string('my-res?x=foo&x=bar')
+        assert syntax.get_multi('x') == ['foo', 'bar']
+
+    def test_url_encoding_in_positional(self) -> None:
+        syntax = ScopeStringSyntax.from_string('my-res:my%20pos')
+        assert syntax.positional == 'my pos'
+
+    def test_url_encoding_in_params(self) -> None:
+        syntax = ScopeStringSyntax.from_string('my-res?x=my%20value')
+        assert syntax.get_single('x') == 'my value'
+
+    def test_colon_in_positional(self) -> None:
+        syntax = ScopeStringSyntax.from_string('my-res:my:pos')
+        assert syntax.positional == 'my:pos'
+
+    def test_rpc_scope_with_did_in_params(self) -> None:
+        """DID values in params contain colons which should not be treated as positional."""
+        syntax = ScopeStringSyntax.from_string('rpc:foo.bar?aud=did:foo:bar?lxm=bar.baz')
+        assert syntax.prefix == 'rpc'
+        assert syntax.positional == 'foo.bar'
+        # parse_qs splits on & only; the inner ? is part of the value
+        aud_values = syntax.get_multi('aud')
+        assert aud_values == ['did:foo:bar?lxm=bar.baz']
+
+
+# ---------------------------------------------------------------------------
+# RepoPermission
+# ---------------------------------------------------------------------------
+
+
+class TestRepoPermission:
+    """Tests for repo permission parsing and matching."""
+
+    def test_parse_positional(self) -> None:
+        scope = RepoPermission.from_string('repo:com.example.foo')
+        assert scope is not None
+        assert scope.collection == ('com.example.foo',)
+        assert scope.action == ('create', 'update', 'delete')
+
+    def test_parse_with_actions(self) -> None:
+        scope = RepoPermission.from_string('repo:com.example.foo?action=create&action=update')
+        assert scope is not None
+        assert scope.collection == ('com.example.foo',)
+        assert scope.action == ('create', 'update')
+
+    def test_parse_without_actions_defaults_to_all(self) -> None:
+        scope = RepoPermission.from_string('repo:com.example.foo')
+        assert scope is not None
+        assert scope.action == ('create', 'update', 'delete')
+
+    def test_wildcard_collection_with_action(self) -> None:
+        scope = RepoPermission.from_string('repo:*?action=create')
+        assert scope is not None
+        assert scope.collection == ('*',)
+        assert scope.action == ('create',)
+        assert scope.matches(collection='any.collection.name', action='create')
+        assert not scope.matches(collection='any.collection.name', action='update')
+
+    def test_wildcard_collection_without_actions(self) -> None:
+        scope = RepoPermission.from_string('repo:*')
+        assert scope is not None
+        assert scope.matches(collection='any.collection.name', action='create')
+        assert scope.matches(collection='any.collection.name', action='update')
+        assert scope.matches(collection='any.collection.name', action='delete')
+
+    @pytest.mark.parametrize(
+        'invalid',
+        [
+            'repo:foo bar',
+            'repo:.foo',
+            'repo:bar.',
+            'repo:*?action=*',
+            'invalid',
+            'repo:invalid',
+            'repo:com.example.foo?action=invalid',
+            'repo?collection=invalid&action=invalid',
+        ],
+    )
+    def test_rejects_invalid(self, invalid: str) -> None:
+        assert RepoPermission.from_string(invalid) is None
+
+    def test_matches_create_action(self) -> None:
+        scope = RepoPermission.from_string('repo:com.example.foo?action=create')
+        assert scope is not None
+        assert scope.matches(action='create', collection='com.example.foo')
+
+    def test_not_matches_unspecified_action(self) -> None:
+        scope = RepoPermission.from_string('repo:com.example.foo?action=create')
+        assert scope is not None
+        assert not scope.matches(action='update', collection='com.example.foo')
+
+    def test_matches_wildcard_collection(self) -> None:
+        scope = RepoPermission.from_string('repo:*?action=create')
+        assert scope is not None
+        assert scope.matches(action='create', collection='com.example.bar')
+
+    def test_matches_multiple_actions(self) -> None:
+        scope = RepoPermission.from_string('repo:com.example.foo?action=create&action=update')
+        assert scope is not None
+        assert scope.matches(action='create', collection='com.example.foo')
+        assert scope.matches(action='update', collection='com.example.foo')
+        assert not scope.matches(action='delete', collection='com.example.foo')
+
+    def test_scope_needed_for(self) -> None:
+        scope = RepoPermission.scope_needed_for(collection='com.example.foo', action='create')
+        assert scope == 'repo:com.example.foo?action=create'
+
+    def test_format(self) -> None:
+        scope = RepoPermission(collection=('com.example.foo',), action=('create', 'update'))
+        assert str(scope) == 'repo:com.example.foo?action=create&action=update'
+
+    @pytest.mark.parametrize(
+        'input_scope,expected',
+        [
+            ('repo:com.example.foo', 'repo:com.example.foo'),
+            ('repo:com.example.foo?action=create', 'repo:com.example.foo?action=create'),
+            ('repo:com.example.foo?action=create&action=update', 'repo:com.example.foo?action=create&action=update'),
+            ('repo:*?action=create&action=update&action=delete', 'repo:*'),
+            ('repo:com.example.foo?action=create&action=update&action=delete', 'repo:com.example.foo'),
+            ('repo:*?action=create', 'repo:*?action=create'),
+            ('repo:*?action=update', 'repo:*?action=update'),
+            ('repo?collection=*&action=update', 'repo:*?action=update'),
+            ('repo?collection=*&collection=com.example.foo&action=update', 'repo:*?action=update'),
+            ('repo?collection=*', 'repo:*'),
+            ('repo?collection=*&action=create&action=update&action=delete', 'repo:*'),
+            ('repo?collection=*&collection=com.example.foo', 'repo:*'),
+            ('repo?action=create&collection=com.example.foo', 'repo:com.example.foo?action=create'),
+            (
+                'repo?collection=com.example.foo&action=create&action=update&action=delete',
+                'repo:com.example.foo',
+            ),
+            (
+                'repo?action=create&collection=com.example.foo&collection=com.example.bar',
+                'repo?collection=com.example.bar&collection=com.example.foo&action=create',
+            ),
+        ],
+    )
+    def test_normalization_roundtrip(self, input_scope: str, expected: str) -> None:
+        result = RepoPermission.from_string(input_scope)
+        assert result is not None
+        assert str(result) == expected
+
+
+# ---------------------------------------------------------------------------
+# BlobPermission
+# ---------------------------------------------------------------------------
+
+
+class TestBlobPermission:
+    """Tests for blob permission parsing and matching."""
+
+    def test_parse_positional(self) -> None:
+        scope = BlobPermission.from_string('blob:image/png')
+        assert scope is not None
+        assert scope.accept == ('image/png',)
+
+    def test_parse_multiple_accept(self) -> None:
+        scope = BlobPermission.from_string('blob?accept=image/png&accept=image/jpeg')
+        assert scope is not None
+        assert set(scope.accept) == {'image/png', 'image/jpeg'}
+
+    def test_reject_without_accept(self) -> None:
+        assert BlobPermission.from_string('blob') is None
+
+    @pytest.mark.parametrize(
+        'invalid',
+        [
+            'invalid',
+            'scope',
+            'blob:invalid',
+            'blob?accept=invalid-mime',
+            'blob?accept=invalid',
+            'blob:*/**',
+            'blob:*/png',
+        ],
+    )
+    def test_rejects_invalid(self, invalid: str) -> None:
+        assert BlobPermission.from_string(invalid) is None
+
+    def test_matches_exact_mime(self) -> None:
+        scope = BlobPermission.from_string('blob:image/png')
+        assert scope is not None
+        assert scope.matches('image/png')
+
+    def test_matches_wildcard_all(self) -> None:
+        scope = BlobPermission.from_string('blob:*/*')
+        assert scope is not None
+        assert scope.matches('image/jpeg')
+        assert scope.matches('application/json')
+
+    def test_matches_subtype_wildcard(self) -> None:
+        scope = BlobPermission.from_string('blob:image/*')
+        assert scope is not None
+        assert scope.matches('image/gif')
+        assert not scope.matches('application/json')
+
+    def test_not_matches_different_mime(self) -> None:
+        scope = BlobPermission.from_string('blob:image/png')
+        assert scope is not None
+        assert not scope.matches('image/jpeg')
+
+    def test_matches_multiple_accept(self) -> None:
+        scope = BlobPermission.from_string('blob?accept=image/png&accept=image/jpeg')
+        assert scope is not None
+        assert scope.matches('image/png')
+        assert scope.matches('image/jpeg')
+        assert not scope.matches('image/gif')
+
+    def test_scope_needed_for(self) -> None:
+        assert BlobPermission.scope_needed_for('image/png') == 'blob:image/png'
+
+    def test_strips_redundant_accept(self) -> None:
+        assert str(BlobPermission(accept=('*/*', 'image/*'))) == 'blob:*/*'
+        assert str(BlobPermission(accept=('*/*', 'image/png'))) == 'blob:*/*'
+        assert str(BlobPermission(accept=('image/*', 'image/png'))) == 'blob:image/*'
+
+    def test_positional_format_for_single(self) -> None:
+        assert str(BlobPermission(accept=('image/png',))) == 'blob:image/png'
+        assert str(BlobPermission(accept=('image/*',))) == 'blob:image/*'
+        assert str(BlobPermission(accept=('*/*',))) == 'blob:*/*'
+
+    def test_query_format_for_multiple(self) -> None:
+        result = str(BlobPermission(accept=('image/png', 'image/jpeg')))
+        assert result == 'blob?accept=image/jpeg&accept=image/png'
+
+
+# ---------------------------------------------------------------------------
+# RpcPermission
+# ---------------------------------------------------------------------------
+
+
+class TestRpcPermission:
+    """Tests for RPC permission parsing and matching."""
+
+    def test_parse_positional_with_aud(self) -> None:
+        scope = RpcPermission.from_string('rpc:com.example.service?aud=did:web:example.com%23service_id')
+        assert scope is not None
+        assert scope.aud == 'did:web:example.com#service_id'
+        assert scope.lxm == ('com.example.service',)
+
+    def test_parse_query_format(self) -> None:
+        scope = RpcPermission.from_string('rpc?lxm=com.example.method1&aud=*')
+        assert scope is not None
+        assert scope.aud == '*'
+        assert scope.lxm == ('com.example.method1',)
+
+    def test_parse_positional_equivalent(self) -> None:
+        scope = RpcPermission.from_string('rpc:com.example.method1?aud=*')
+        assert scope is not None
+        assert scope.aud == '*'
+        assert scope.lxm == ('com.example.method1',)
+
+    def test_parse_multiple_lxm(self) -> None:
+        scope = RpcPermission.from_string('rpc?aud=*&lxm=com.example.method1&lxm=com.example.method2')
+        assert scope is not None
+        assert scope.aud == '*'
+        assert scope.lxm == ('com.example.method1', 'com.example.method2')
+
+    def test_rejects_without_lxm(self) -> None:
+        assert RpcPermission.from_string('rpc?aud=did:web:example.com%23service_id') is None
+        assert RpcPermission.from_string('rpc:?aud=did:web:example.com%23service_id') is None
+
+    def test_rejects_without_aud(self) -> None:
+        assert RpcPermission.from_string('rpc?lxm=com.example.method1') is None
+        assert RpcPermission.from_string('rpc:com.example.method1') is None
+
+    def test_rejects_positional_and_query_lxm(self) -> None:
+        assert (
+            RpcPermission.from_string('rpc:com.example.method1?aud=did:web:example.com&lxm=com.example.method2') is None
+        )
+
+    def test_rejects_wildcard_aud_and_lxm(self) -> None:
+        assert RpcPermission.from_string('rpc?aud=*&lxm=*') is None
+        assert RpcPermission.from_string('rpc:*?aud=*') is None
+
+    @pytest.mark.parametrize(
+        'invalid',
+        [
+            'rpc:*',
+            'invalid',
+            'rpc:invalid',
+            'rpc:com.example.service',
+            'rpc:invalid?aud=did:web:example.com',
+            'rpc:com.example.service?aud=invalid',
+            'rpc?lxm=invalid&aud=invalid',
+        ],
+    )
+    def test_rejects_invalid(self, invalid: str) -> None:
+        assert RpcPermission.from_string(invalid) is None
+
+    def test_matches_exact(self) -> None:
+        scope = RpcPermission.from_string('rpc:com.example.service?aud=did:web:example.com%23service_id')
+        assert scope is not None
+        assert scope.matches(lxm='com.example.service', aud='did:web:example.com#service_id')
+
+    def test_not_matches_different_lxm(self) -> None:
+        scope = RpcPermission.from_string('rpc:com.example.service?aud=did:web:example.com%23service_id')
+        assert scope is not None
+        assert not scope.matches(lxm='com.example.OtherService', aud='did:web:example.com#service_id')
+
+    def test_not_matches_different_aud(self) -> None:
+        scope = RpcPermission.from_string('rpc:com.example.service?aud=did:web:example.com%23service_id')
+        assert scope is not None
+        assert not scope.matches(lxm='com.example.service', aud='did:example:456#service_id')
+
+    def test_matches_wildcard_aud(self) -> None:
+        scope = RpcPermission.from_string('rpc:com.example.method1?aud=*')
+        assert scope is not None
+        assert scope.matches(lxm='com.example.method1', aud='did:web:example.com#service_id')
+
+    def test_matches_wildcard_lxm(self) -> None:
+        scope = RpcPermission.from_string('rpc:*?aud=did:web:example.com%23service_id')
+        assert scope is not None
+        assert scope.matches(lxm='com.example.method1', aud='did:web:example.com#service_id')
+
+    def test_scope_needed_for(self) -> None:
+        scope = RpcPermission.scope_needed_for(lxm='com.example.service', aud='did:web:example.com#service_id')
+        assert scope == 'rpc:com.example.service?aud=did:web:example.com%23service_id'
+
+    def test_format_with_fragment(self) -> None:
+        scope = RpcPermission(aud='did:web:example.com#service_id', lxm=('com.example.service',))
+        assert str(scope) == 'rpc:com.example.service?aud=did:web:example.com%23service_id'
+
+    def test_simplifies_wildcard_lxm(self) -> None:
+        scope = RpcPermission(
+            aud='did:web:example.com#service_id',
+            lxm=('*', 'com.example.method1'),
+        )
+        assert str(scope) == 'rpc:*?aud=did:web:example.com%23service_id'
+
+    @pytest.mark.parametrize(
+        'input_scope,expected',
+        [
+            (
+                'rpc:com.example.service?aud=did:web:example.com%23service_id',
+                'rpc:com.example.service?aud=did:web:example.com%23service_id',
+            ),
+            (
+                'rpc:com.example.service?aud=did:web:example.com#service_id',
+                'rpc:com.example.service?aud=did:web:example.com%23service_id',
+            ),
+            (
+                'rpc?lxm=com.example.method1&lxm=com.example.method2&aud=*',
+                'rpc?lxm=com.example.method1&lxm=com.example.method2&aud=*',
+            ),
+            (
+                'rpc?lxm=com.example.method1&lxm=com.example.method2&lxm=*&aud=did:web:example.com%23service_id',
+                'rpc:*?aud=did:web:example.com%23service_id',
+            ),
+            (
+                'rpc?aud=did:web:example.com%23foo&lxm=com.example.service',
+                'rpc:com.example.service?aud=did:web:example.com%23foo',
+            ),
+            (
+                'rpc?lxm=com.example.method1&aud=did:web:example.com#foo',
+                'rpc:com.example.method1?aud=did:web:example.com%23foo',
+            ),
+            (
+                'rpc:com.example.method1?&aud=*',
+                'rpc:com.example.method1?aud=*',
+            ),
+        ],
+    )
+    def test_normalization_roundtrip(self, input_scope: str, expected: str) -> None:
+        result = RpcPermission.from_string(input_scope)
+        assert result is not None, f'Failed to parse {input_scope}'
+        assert str(result) == expected
+
+
+# ---------------------------------------------------------------------------
+# AccountPermission
+# ---------------------------------------------------------------------------
+
+
+class TestAccountPermission:
+    """Tests for account permission parsing and matching."""
+
+    def test_parse_email_default_action(self) -> None:
+        scope = AccountPermission.from_string('account:email')
+        assert scope is not None
+        assert scope.attr == 'email'
+        assert scope.action == ('read',)
+
+    def test_parse_with_manage(self) -> None:
+        scope = AccountPermission.from_string('account:repo?action=manage')
+        assert scope is not None
+        assert scope.attr == 'repo'
+        assert scope.action == ('manage',)
+
+    def test_manage_implies_read(self) -> None:
+        scope = AccountPermission.from_string('account:repo?action=manage')
+        assert scope is not None
+        assert scope.matches(attr='repo', action='read')
+        assert scope.matches(attr='repo', action='manage')
+
+    def test_read_does_not_imply_manage(self) -> None:
+        scope = AccountPermission.from_string('account:email')
+        assert scope is not None
+        assert scope.matches(attr='email', action='read')
+        assert not scope.matches(attr='email', action='manage')
+
+    def test_attr_must_match(self) -> None:
+        scope = AccountPermission.from_string('account:email')
+        assert scope is not None
+        assert not scope.matches(attr='repo', action='read')
+
+    @pytest.mark.parametrize('attr', ['email', 'repo', 'status'])
+    def test_all_attributes(self, attr: str) -> None:
+        scope = AccountPermission.from_string(f'account:{attr}')
+        assert scope is not None
+        assert scope.attr == attr
+
+    def test_rejects_invalid_attribute(self) -> None:
+        assert AccountPermission.from_string('account:invalid') is None
+
+    def test_scope_needed_for(self) -> None:
+        assert AccountPermission.scope_needed_for(attr='email', action='read') == 'account:email'
+        assert AccountPermission.scope_needed_for(attr='repo', action='manage') == 'account:repo?action=manage'
+
+
+# ---------------------------------------------------------------------------
+# IdentityPermission
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityPermission:
+    """Tests for identity permission parsing and matching."""
+
+    def test_parse_handle(self) -> None:
+        scope = IdentityPermission.from_string('identity:handle')
+        assert scope is not None
+        assert scope.attr == 'handle'
+
+    def test_parse_wildcard(self) -> None:
+        scope = IdentityPermission.from_string('identity:*')
+        assert scope is not None
+        assert scope.attr == '*'
+
+    def test_wildcard_matches_handle(self) -> None:
+        scope = IdentityPermission.from_string('identity:*')
+        assert scope is not None
+        assert scope.matches('handle')
+
+    def test_handle_matches_handle(self) -> None:
+        scope = IdentityPermission.from_string('identity:handle')
+        assert scope is not None
+        assert scope.matches('handle')
+
+    def test_handle_does_not_match_wildcard(self) -> None:
+        scope = IdentityPermission.from_string('identity:handle')
+        assert scope is not None
+        assert not scope.matches('*')
+
+    def test_rejects_invalid(self) -> None:
+        assert IdentityPermission.from_string('identity:invalid') is None
+        assert IdentityPermission.from_string('invalid') is None
+
+
+# ---------------------------------------------------------------------------
+# IncludeScope
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeScope:
+    """Tests for include scope parsing."""
+
+    def test_parse(self) -> None:
+        scope = IncludeScope.from_string('include:fm.plyr.authFullApp')
+        assert scope is not None
+        assert scope.nsid == 'fm.plyr.authFullApp'
+        assert scope.aud is None
+
+    def test_parse_with_aud(self) -> None:
+        scope = IncludeScope.from_string('include:fm.plyr.authFullApp?aud=did:web:example.com')
+        assert scope is not None
+        assert scope.nsid == 'fm.plyr.authFullApp'
+        assert scope.aud == 'did:web:example.com'
+
+    def test_is_parent_authority_of_same_namespace(self) -> None:
+        scope = IncludeScope(nsid='fm.plyr.authFullApp')
+        assert scope.is_parent_authority_of('fm.plyr.track')
+        assert scope.is_parent_authority_of('fm.plyr.like')
+
+    def test_is_parent_authority_of_different_namespace(self) -> None:
+        scope = IncludeScope(nsid='fm.plyr.authFullApp')
+        assert not scope.is_parent_authority_of('com.other.thing')
+
+    def test_is_parent_authority_of_wildcard(self) -> None:
+        scope = IncludeScope(nsid='fm.plyr.authFullApp')
+        assert not scope.is_parent_authority_of('*')
+
+    def test_rejects_invalid_nsid(self) -> None:
+        assert IncludeScope.from_string('include:invalid') is None
+        assert IncludeScope.from_string('include:a.b') is None
+
+    def test_format_roundtrip(self) -> None:
+        scope = IncludeScope(nsid='fm.plyr.authFullApp')
+        assert str(scope) == 'include:fm.plyr.authFullApp'
+
+
+# ---------------------------------------------------------------------------
+# ScopesSet
+# ---------------------------------------------------------------------------
+
+
+class TestScopesSet:
+    """Tests for the ScopesSet container."""
+
+    def test_empty_set(self) -> None:
+        ss = ScopesSet()
+        assert ss.size == 0
+
+    def test_add_and_has(self) -> None:
+        ss = ScopesSet()
+        ss.add('repo:read')
+        assert ss.size == 1
+        assert ss.has('repo:read')
+        assert not ss.has('repo:write')
+
+    def test_discard(self) -> None:
+        ss = ScopesSet(['repo:read'])
+        ss.discard('repo:read')
+        assert ss.size == 0
+
+    def test_from_string(self) -> None:
+        ss = ScopesSet.from_string('atproto repo:com.example.foo blob:*/*')
+        assert ss.has('atproto')
+        assert ss.has('repo:com.example.foo')
+        assert ss.has('blob:*/*')
+
+    def test_matches_repo(self) -> None:
+        ss = ScopesSet(['repo:com.example.foo'])
+        assert ss.matches('repo', collection='com.example.foo', action='create')
+        assert not ss.matches('repo', collection='com.example.bar', action='create')
+
+    def test_not_matches_action(self) -> None:
+        ss = ScopesSet(['repo:com.example.foo?action=create'])
+        assert not ss.matches('repo', collection='com.example.foo', action='delete')
+
+    def test_not_matches_invalid_scope(self) -> None:
+        ss = ScopesSet(['repo:not-a-valid-nsid'])
+        assert not ss.matches('repo', collection='not-a-valid-nsid', action='create')
+
+    def test_assert_matches_raises(self) -> None:
+        ss = ScopesSet(['repo:com.example.foo'])
+        with pytest.raises(ScopeMissingError) as exc_info:
+            ss.assert_matches('repo', collection='com.example.bar', action='create')
+        assert 'com.example.bar' in exc_info.value.scope
+
+
+# ---------------------------------------------------------------------------
+# ScopePermissions
+# ---------------------------------------------------------------------------
+
+
+class TestScopePermissions:
+    """Tests for the typed ScopePermissions facade."""
+
+    def test_allows_repo(self) -> None:
+        perms = ScopePermissions('repo:com.example.foo blob:*/*')
+        assert perms.allows_repo('com.example.foo', 'create')
+        assert not perms.allows_repo('com.example.bar', 'create')
+
+    def test_allows_blob(self) -> None:
+        perms = ScopePermissions('blob:*/*')
+        assert perms.allows_blob('image/png')
+
+    def test_allows_rpc(self) -> None:
+        perms = ScopePermissions('rpc:com.example.foo?aud=*')
+        assert perms.allows_rpc('com.example.foo', 'did:web:example.com')
+
+    def test_allows_account(self) -> None:
+        perms = ScopePermissions('account:email')
+        assert perms.allows_account('email', 'read')
+        assert not perms.allows_account('email', 'manage')
+
+    def test_allows_identity(self) -> None:
+        perms = ScopePermissions('identity:*')
+        assert perms.allows_identity('handle')
+
+    def test_assert_repo_raises(self) -> None:
+        perms = ScopePermissions('repo:com.example.foo')
+        with pytest.raises(ScopeMissingError):
+            perms.assert_repo('com.example.bar', 'create')
+
+
+# ---------------------------------------------------------------------------
+# ScopePermissionsTransition
+# ---------------------------------------------------------------------------
+
+
+class TestScopePermissionsTransition:
+    """Tests for transition scope handling."""
+
+    def test_transition_email_allows_account_email_read(self) -> None:
+        perms = ScopePermissionsTransition('transition:email account:repo')
+        assert perms.allows_account('email', 'read')
+        assert not perms.allows_account('email', 'manage')
+        assert perms.allows_account('repo', 'read')
+        assert not perms.allows_account('repo', 'manage')
+        assert not perms.allows_account('status', 'read')
+
+    def test_transition_generic_allows_blob(self) -> None:
+        perms = ScopePermissionsTransition('transition:generic')
+        assert perms.allows_blob('foo/bar')
+
+    def test_transition_generic_allows_repo(self) -> None:
+        perms = ScopePermissionsTransition('transition:generic')
+        assert perms.allows_repo('app.bsky.feed.post', 'create')
+        assert perms.allows_repo('app.bsky.feed.post', 'delete')
+        assert perms.allows_repo('com.example.foo', 'create')
+
+    def test_transition_generic_allows_non_chat_rpc(self) -> None:
+        perms = ScopePermissionsTransition('transition:generic')
+        assert perms.allows_rpc('app.bsky.feed.post', 'did:web:example.com')
+        assert perms.allows_rpc('com.example.foo', 'did:web:example.com')
+        assert perms.allows_rpc('*', 'did:web:example.com')
+
+    def test_transition_generic_rejects_chat_rpc(self) -> None:
+        perms = ScopePermissionsTransition('transition:generic')
+        assert not perms.allows_rpc('chat.bsky.message.send', 'did:web:example.com')
+        assert not perms.allows_rpc('chat.bsky.conversation.get', 'did:web:example.com')
+
+    def test_transition_chat_bsky_allows_chat_rpc(self) -> None:
+        perms = ScopePermissionsTransition('transition:chat.bsky')
+        assert perms.allows_rpc('chat.bsky.message.send', 'did:web:example.com')
+        assert perms.allows_rpc('chat.bsky.conversation.get', 'did:web:example.com')
+
+    def test_transition_chat_bsky_rejects_non_chat_rpc(self) -> None:
+        perms = ScopePermissionsTransition('transition:chat.bsky')
+        assert not perms.allows_rpc('app.bsky.feed.post', 'did:web:example.com')
+        assert not perms.allows_rpc('com.example.foo', 'did:web:example.com')
+        assert not perms.allows_rpc('*', 'did:web:example.com')
+
+
+# ---------------------------------------------------------------------------
+# _scopes_are_equivalent
+# ---------------------------------------------------------------------------
+
+
+class TestScopesAreEquivalent:
+    """Tests for the SDK-level scope equivalence check."""
+
+    def test_exact_match(self) -> None:
+        assert _scopes_are_equivalent(
+            'atproto repo:fm.plyr.track',
+            'atproto repo:fm.plyr.track',
+        )
+
+    def test_format_equivalence(self) -> None:
+        """repo:nsid == repo?collection=nsid."""
+        assert _scopes_are_equivalent(
+            'atproto repo:fm.plyr.track',
+            'atproto repo?collection=fm.plyr.track',
+        )
+
+    def test_include_expansion(self) -> None:
+        """include:namespace.permSet is satisfied by repo?collection= in that namespace."""
+        assert _scopes_are_equivalent(
+            'atproto include:fm.plyr.authFullApp',
+            'atproto repo?collection=fm.plyr.track&collection=fm.plyr.like',
+        )
+
+    def test_include_expansion_with_positional(self) -> None:
+        """include:namespace.permSet is satisfied by repo:ns.collection."""
+        assert _scopes_are_equivalent(
+            'atproto include:fm.plyr.authFullApp',
+            'atproto repo:fm.plyr.track repo:fm.plyr.like',
+        )
+
+    def test_missing_scope(self) -> None:
+        assert not _scopes_are_equivalent(
+            'atproto repo:fm.plyr.track repo:fm.plyr.like',
+            'atproto repo:fm.plyr.track',
+        )
+
+    def test_extra_granted_ok(self) -> None:
+        assert _scopes_are_equivalent(
+            'atproto repo:fm.plyr.track',
+            'atproto repo:fm.plyr.track repo:fm.plyr.like blob:*/*',
+        )
+
+    def test_include_wrong_namespace(self) -> None:
+        assert not _scopes_are_equivalent(
+            'atproto include:fm.plyr.authFullApp',
+            'atproto repo?collection=com.other.thing',
+        )
+
+    def test_transition_scopes_exact_match(self) -> None:
+        assert _scopes_are_equivalent(
+            'atproto transition:generic',
+            'atproto transition:generic',
+        )
+
+    def test_transition_scopes_missing(self) -> None:
+        assert not _scopes_are_equivalent(
+            'atproto transition:generic',
+            'atproto repo:com.example.foo',
+        )
+
+    def test_blob_equivalence(self) -> None:
+        assert _scopes_are_equivalent(
+            'atproto blob:*/*',
+            'atproto blob:*/*',
+        )
+
+    def test_empty_scopes(self) -> None:
+        assert _scopes_are_equivalent('', '')
+
+    def test_repo_wildcard_covers_specific(self) -> None:
+        """repo:* should cover any specific collection."""
+        assert _scopes_are_equivalent(
+            'atproto repo:fm.plyr.track',
+            'atproto repo:*',
+        )
+
+    def test_action_mismatch(self) -> None:
+        """repo with limited actions should not cover all-action request."""
+        assert not _scopes_are_equivalent(
+            'atproto repo:fm.plyr.track',
+            'atproto repo:fm.plyr.track?action=create',
+        )
+
+    def test_blob_wildcard_covers_specific(self) -> None:
+        """granted blob:*/* should cover requested blob:image/png."""
+        assert _scopes_are_equivalent(
+            'atproto blob:image/png',
+            'atproto blob:*/*',
+        )
+
+    def test_granted_superset_actions(self) -> None:
+        """granted all-actions should cover limited-action request."""
+        assert _scopes_are_equivalent(
+            'atproto repo:fm.plyr.track?action=create',
+            'atproto repo:fm.plyr.track',
+        )
+
+
+# ---------------------------------------------------------------------------
+# MIME helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMime:
+    """Tests for MIME matching utilities."""
+
+    def test_is_mime_valid(self) -> None:
+        assert is_mime('image/png')
+        assert is_mime('application/json')
+
+    def test_is_mime_rejects_wildcards(self) -> None:
+        assert not is_mime('*/*')
+        assert not is_mime('image/*')
+
+    def test_is_mime_rejects_invalid(self) -> None:
+        assert not is_mime('invalid')
+        assert not is_mime('a/b/c')
+        assert not is_mime('/png')
+        assert not is_mime('image/')
+
+    def test_is_accept_valid(self) -> None:
+        assert is_accept('*/*')
+        assert is_accept('image/*')
+        assert is_accept('image/png')
+
+    def test_is_accept_rejects_invalid(self) -> None:
+        assert not is_accept('invalid')
+        assert not is_accept('*/png')
+        assert not is_accept('*/**')
+
+    def test_matches_accept_wildcard(self) -> None:
+        assert matches_accept('*/*', 'image/png')
+
+    def test_matches_accept_subtype_wildcard(self) -> None:
+        assert matches_accept('image/*', 'image/png')
+        assert not matches_accept('image/*', 'application/json')
+
+    def test_matches_accept_exact(self) -> None:
+        assert matches_accept('image/png', 'image/png')
+        assert not matches_accept('image/png', 'image/jpeg')
+
+    def test_matches_any_accept(self) -> None:
+        patterns = ['image/png', 'image/jpeg']
+        assert matches_any_accept(patterns, 'image/png')
+        assert matches_any_accept(patterns, 'image/jpeg')
+        assert not matches_any_accept(patterns, 'image/gif')

--- a/tests/test_oauth_scopes.py
+++ b/tests/test_oauth_scopes.py
@@ -548,28 +548,28 @@ class TestIncludeScope:
     """Tests for include scope parsing."""
 
     def test_parse(self) -> None:
-        scope = IncludeScope.from_string('include:fm.plyr.authFullApp')
+        scope = IncludeScope.from_string('include:com.example.appPermissions')
         assert scope is not None
-        assert scope.nsid == 'fm.plyr.authFullApp'
+        assert scope.nsid == 'com.example.appPermissions'
         assert scope.aud is None
 
     def test_parse_with_aud(self) -> None:
-        scope = IncludeScope.from_string('include:fm.plyr.authFullApp?aud=did:web:example.com')
+        scope = IncludeScope.from_string('include:com.example.appPermissions?aud=did:web:example.com')
         assert scope is not None
-        assert scope.nsid == 'fm.plyr.authFullApp'
+        assert scope.nsid == 'com.example.appPermissions'
         assert scope.aud == 'did:web:example.com'
 
     def test_is_parent_authority_of_same_namespace(self) -> None:
-        scope = IncludeScope(nsid='fm.plyr.authFullApp')
-        assert scope.is_parent_authority_of('fm.plyr.track')
-        assert scope.is_parent_authority_of('fm.plyr.like')
+        scope = IncludeScope(nsid='com.example.appPermissions')
+        assert scope.is_parent_authority_of('com.example.record')
+        assert scope.is_parent_authority_of('com.example.like')
 
     def test_is_parent_authority_of_different_namespace(self) -> None:
-        scope = IncludeScope(nsid='fm.plyr.authFullApp')
+        scope = IncludeScope(nsid='com.example.appPermissions')
         assert not scope.is_parent_authority_of('com.other.thing')
 
     def test_is_parent_authority_of_wildcard(self) -> None:
-        scope = IncludeScope(nsid='fm.plyr.authFullApp')
+        scope = IncludeScope(nsid='com.example.appPermissions')
         assert not scope.is_parent_authority_of('*')
 
     def test_rejects_invalid_nsid(self) -> None:
@@ -577,8 +577,8 @@ class TestIncludeScope:
         assert IncludeScope.from_string('include:a.b') is None
 
     def test_format_roundtrip(self) -> None:
-        scope = IncludeScope(nsid='fm.plyr.authFullApp')
-        assert str(scope) == 'include:fm.plyr.authFullApp'
+        scope = IncludeScope(nsid='com.example.appPermissions')
+        assert str(scope) == 'include:com.example.appPermissions'
 
 
 # ---------------------------------------------------------------------------
@@ -726,46 +726,46 @@ class TestScopesAreEquivalent:
 
     def test_exact_match(self) -> None:
         assert _scopes_are_equivalent(
-            'atproto repo:fm.plyr.track',
-            'atproto repo:fm.plyr.track',
+            'atproto repo:com.example.record',
+            'atproto repo:com.example.record',
         )
 
     def test_format_equivalence(self) -> None:
         """repo:nsid == repo?collection=nsid."""
         assert _scopes_are_equivalent(
-            'atproto repo:fm.plyr.track',
-            'atproto repo?collection=fm.plyr.track',
+            'atproto repo:com.example.record',
+            'atproto repo?collection=com.example.record',
         )
 
     def test_include_expansion(self) -> None:
         """include:namespace.permSet is satisfied by repo?collection= in that namespace."""
         assert _scopes_are_equivalent(
-            'atproto include:fm.plyr.authFullApp',
-            'atproto repo?collection=fm.plyr.track&collection=fm.plyr.like',
+            'atproto include:com.example.appPermissions',
+            'atproto repo?collection=com.example.record&collection=com.example.like',
         )
 
     def test_include_expansion_with_positional(self) -> None:
         """include:namespace.permSet is satisfied by repo:ns.collection."""
         assert _scopes_are_equivalent(
-            'atproto include:fm.plyr.authFullApp',
-            'atproto repo:fm.plyr.track repo:fm.plyr.like',
+            'atproto include:com.example.appPermissions',
+            'atproto repo:com.example.record repo:com.example.like',
         )
 
     def test_missing_scope(self) -> None:
         assert not _scopes_are_equivalent(
-            'atproto repo:fm.plyr.track repo:fm.plyr.like',
-            'atproto repo:fm.plyr.track',
+            'atproto repo:com.example.record repo:com.example.like',
+            'atproto repo:com.example.record',
         )
 
     def test_extra_granted_ok(self) -> None:
         assert _scopes_are_equivalent(
-            'atproto repo:fm.plyr.track',
-            'atproto repo:fm.plyr.track repo:fm.plyr.like blob:*/*',
+            'atproto repo:com.example.record',
+            'atproto repo:com.example.record repo:com.example.like blob:*/*',
         )
 
     def test_include_wrong_namespace(self) -> None:
         assert not _scopes_are_equivalent(
-            'atproto include:fm.plyr.authFullApp',
+            'atproto include:com.example.appPermissions',
             'atproto repo?collection=com.other.thing',
         )
 
@@ -793,15 +793,15 @@ class TestScopesAreEquivalent:
     def test_repo_wildcard_covers_specific(self) -> None:
         """repo:* should cover any specific collection."""
         assert _scopes_are_equivalent(
-            'atproto repo:fm.plyr.track',
+            'atproto repo:com.example.record',
             'atproto repo:*',
         )
 
     def test_action_mismatch(self) -> None:
         """repo with limited actions should not cover all-action request."""
         assert not _scopes_are_equivalent(
-            'atproto repo:fm.plyr.track',
-            'atproto repo:fm.plyr.track?action=create',
+            'atproto repo:com.example.record',
+            'atproto repo:com.example.record?action=create',
         )
 
     def test_blob_wildcard_covers_specific(self) -> None:
@@ -814,8 +814,8 @@ class TestScopesAreEquivalent:
     def test_granted_superset_actions(self) -> None:
         """granted all-actions should cover limited-action request."""
         assert _scopes_are_equivalent(
-            'atproto repo:fm.plyr.track?action=create',
-            'atproto repo:fm.plyr.track',
+            'atproto repo:com.example.record?action=create',
+            'atproto repo:com.example.record',
         )
 
 


### PR DESCRIPTION
## Summary

> **Rebased onto `main` @ `15b949947` (2026-08-08).** The PR had gone stale and was showing
> conflicts — the only one was `pyproject.toml`, where upstream added `E501` to the
> `atproto_client/models/__init__.py` per-file ignores while this branch added the
> `atproto_oauth/*.py` ignores. Resolved by keeping both. Everything else merged cleanly,
> since the package is additive. All 22 checks green: ruff, `format --check`, codegen on
> 3 platforms, and unit tests on Python 3.9–3.14 × 3 platforms.

Adds an `atproto_oauth` package implementing OAuth 2.1 for the AT Protocol, aligned with the [official TypeScript SDK](https://github.com/bluesky-social/atproto/tree/main/packages/oauth).

**~4,800 lines** (implementation + tests + docs). Covers the same ground as the [Go SDK (indigo)](https://github.com/bluesky-social/indigo/tree/main/atproto/auth/oauth) plus scope parsing, which indigo omits and the TypeScript reference has.

**Happy to split this into `core` + `scopes` PRs if that is easier to review** — see the note below on why they are together.

### What's included

- **Authorization flow**: PAR, PKCE (S256), DPoP proof generation with nonce rotation
- **Token lifecycle**: exchange, refresh, revocation (access + refresh tokens)
- **Auth server discovery**: PDS → protected resource metadata → authorization server metadata
- **Client authentication**: public (`none`) and confidential (`private_key_jwt`) clients
- **Authenticated requests**: DPoP-signed HTTP helper with automatic nonce retry
- **Session/state stores**: abstract base classes + in-memory implementations
- **Security**: URL validation (SSRF protection), hardened HTTP clients (redirect/connection limits), issuer re-verification after token exchange (prevents impersonation per [spec](https://atproto.com/specs/oauth))
- **Scope parsing**: port of `@atproto/oauth-scopes` — permission syntax, `include:` permission-set expansion, transition scopes, MIME matching
- **Tests**: 194 tests (29 core OAuth + 165 scope parsing)
- **Docs**: Sphinx API reference (auto-generated) + usage guide with quick start examples

### What's NOT included (follow-up PRs)

- Flask demo application
- Auto-refresh on 401 / concurrency safety

### Why scope parsing is in this PR rather than a follow-up

It was previously carved out onto a separate branch. Two things argued for folding it back in:

- `_scopes_are_equivalent` had to ship a **weakened stand-in** without it — plain set comparison
  over scope strings. The real check needs permission-set expansion, because a PDS expands
  `include:namespace.permissionSet` into `repo?collection=...` and the positional (`repo:nsid`)
  and query (`repo?collection=nsid`) forms have to compare equal. That is now correct.
- A "follow-up PR" presupposes this one lands first, and the split had already started to
  drift — the branch it pointed at fell behind.

Still happy to split it back out if you would rather review it in two passes.

### Comparison with other SDKs

| Feature | TypeScript (ref) | Go (indigo) | **This PR** |
|---------|:---:|:---:|:---:|
| PAR + PKCE + DPoP | ✅ | ✅ | ✅ |
| Token refresh/revoke | ✅ | ✅ | ✅ |
| Public + confidential clients | ✅ | ✅ | ✅ |
| Store abstraction | ✅ | ✅ | ✅ |
| Scope parsing | ✅ | ❌ | ✅ |
| Auto-refresh on 401 | ✅ | ✅ | ❌ (follow-up) |

### Files

- `packages/atproto_oauth/` — 11 source files (client, DPoP, PKCE, metadata, models, security, stores)
- `packages/atproto_oauth/scopes/` — 9 source files (parser, syntax, permissions, scopes_set, transition)
- `tests/test_oauth_{client,dpop,pkce,scopes}.py` — 194 tests
- `pyproject.toml` — package entry + ruff per-file-ignores
- `docs/source/atproto/` — generated Sphinx autodoc (via `make -C docs gen`)
- `docs/source/atproto_oauth/index.rst` — usage guide with quick start examples
- `docs/source/index.rst` — registered in SDK toctree

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] All 194 OAuth tests pass locally
- [x] CI: ruff, unit_tests (3.9–3.14, 3 platforms), codegen_check, docs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

