### PR TITLE
Fix lexicon_parse_dir failing on lexicons in subdirectories

### DIFF
--- a/packages/atproto_lexicon/parser.py
+++ b/packages/atproto_lexicon/parser.py
@@ -38,12 +38,12 @@ def lexicon_parse_dir(
 
     parsed_lexicons = []
 
-    for _, _, lexicons in sorted(os.walk(lexicon_dir_path)):
+    for root, _, lexicons in sorted(os.walk(lexicon_dir_path)):
         for lexicon in sorted(lexicons):
             if not lexicon.endswith(_LEXICON_FILE_EXT):
                 continue
 
-            lexicon_path = lexicon_dir_path.joinpath(lexicon)
+            lexicon_path = Path(root).joinpath(lexicon)
             parsed_lexicon = lexicon_parse_file(lexicon_path, soft_fail=soft_fail)
             if parsed_lexicon:
                 parsed_lexicons.append(parsed_lexicon)

--- a/tests/test_atproto_lexicon/test_lexicon_parser.py
+++ b/tests/test_atproto_lexicon/test_lexicon_parser.py
@@ -1,3 +1,6 @@
+import shutil
+from pathlib import Path
+
 from atproto_lexicon.parser import _PATH_TO_LEXICONS, lexicon_parse_file, lexicon_parse_dir  # noqa
 
 
@@ -7,3 +10,15 @@ def test_lexicon_parse_file() -> None:
 
 def test_lexicon_parse_dir() -> None:
     lexicon_parse_dir(_PATH_TO_LEXICONS)
+
+
+def test_lexicon_parse_dir_with_subdirectories(tmp_path: Path) -> None:
+    shutil.copy(_PATH_TO_LEXICONS.joinpath('app.bsky.actor.profile.json'), tmp_path)
+    nested_dir = tmp_path.joinpath('app', 'bsky', 'feed')
+    nested_dir.mkdir(parents=True)
+    shutil.copy(_PATH_TO_LEXICONS.joinpath('app.bsky.feed.post.json'), nested_dir)
+
+    parsed_lexicons = lexicon_parse_dir(tmp_path)
+
+    parsed_ids = {lexicon.id for lexicon in parsed_lexicons}
+    assert parsed_ids == {'app.bsky.actor.profile', 'app.bsky.feed.post'}

--- a/tests/test_atproto_lexicon/test_lexicon_parser.py
+++ b/tests/test_atproto_lexicon/test_lexicon_parser.py
@@ -1,7 +1,7 @@
 import shutil
 from pathlib import Path
 
-from atproto_lexicon.parser import _PATH_TO_LEXICONS, lexicon_parse_file, lexicon_parse_dir  # noqa
+from atproto_lexicon.parser import _PATH_TO_LEXICONS, lexicon_parse_dir, lexicon_parse_file
 
 
 def test_lexicon_parse_file() -> None:


### PR DESCRIPTION
Hi! Found while pointing `lexicon_parse_dir` at a nested lexicon directory during the same spec-conformance work as #695.

`os.walk` recurses into subdirectories, but the loop joins each filename onto the top-level directory instead of the directory the file was actually found in:


```
for _, _, lexicons in sorted(os.walk(lexicon_dir_path)):
    ...
    lexicon_path = lexicon_dir_path.joinpath(lexicon)
```

So for `lexicons/app/bsky/feed/post.json` it attempts to open `lexicons/post.json`. In practice: nested files raise `LexiconParsingError` (masking the underlying `FileNotFoundError`), or with `soft_fail=True` they're silently skipped; and a nested file sharing a name with a top-level one causes the top-level file to be parsed twice. This never surfaces with the bundled `lexicons/` directory because `update_lexicons.py` deliberately flattens filenames on import, but the canonical `bluesky-social/atproto` lexicons tree is nested by NSID segment (the tree I'm using in my conformance testing), so pointing `lexicon_parse_dir` at a checkout of it (probably the most common external input) hits this immediately.

The fix keeps the walk root and joins against it (`Path(root).joinpath(lexicon)`), plus a `tmp_path` test with a nested layout that fails on main and passes here.

Thanks for the library! Happy to tweak anything!