### PR TITLE
Speed up Jetstream 2x and Firehose 1.4x, and fix Firehose frame `op`

### DIFF
--- a/packages/atproto_client/models/string_formats.py
+++ b/packages/atproto_client/models/string_formats.py
@@ -64,14 +64,31 @@ AT_URI_RE = re.compile(
 )
 
 
+def _is_strict(info: ValidationInfo) -> bool:
+    """Whether the caller opted into string format validation through the validation context.
+
+    Runs for every string format field of every model, so the common `dict` context is checked
+    without the (comparatively expensive) `Mapping` ABC lookup.
+    """
+    context = info.context if info else None
+    if isinstance(context, dict):
+        return bool(context.get(_OPT_IN_KEY, False))
+
+    return isinstance(context, Mapping) and bool(context.get(_OPT_IN_KEY, False))
+
+
 class _NamedValidator:
     """Decorator to add a __str__ attribute to a validation function."""
 
     def __init__(self, validate_fn: Callable[..., str]) -> None:
         self.validate_fn = validate_fn
+        # the opt-in gate is applied here, so skip the `only_validate_if_strict` wrapper frame
+        self._strict_fn = getattr(validate_fn, '__wrapped__', validate_fn)
 
     def __call__(self, v: str, info: ValidationInfo) -> str:
-        return self.validate_fn(v, info)
+        if _is_strict(info):
+            return cast('core_schema.WithInfoValidatorFunction', self._strict_fn)(v, info)
+        return v
 
     def __str__(self) -> str:
         func_str = f':func:`string_formats.{self.validate_fn.__name__}`'
@@ -84,7 +101,7 @@ def only_validate_if_strict(validate_fn: Callable[..., str]) -> Callable[..., st
     @wraps(validate_fn)
     def wrapper(v: str, info: ValidationInfo) -> str:
         """Could likely be generalized to support arbitrary signatures."""
-        if info and isinstance(info.context, Mapping) and info.context.get(_OPT_IN_KEY, False):
+        if _is_strict(info):
             return cast('core_schema.WithInfoValidatorFunction', validate_fn)(v, info)
         return v
 

--- a/packages/atproto_client/models/unknown_type.py
+++ b/packages/atproto_client/models/unknown_type.py
@@ -66,5 +66,7 @@ UnknownRecordTypePydantic = te.Annotated[
     ],
     Field(discriminator='py_type'),
 ]
-UnknownType: te.TypeAlias = t.Union[UnknownRecordTypePydantic, 'dot_dict.DotDictType']
+UnknownType: te.TypeAlias = te.Annotated[
+    t.Union[UnknownRecordTypePydantic, 'dot_dict.DotDictType'], Field(union_mode='left_to_right')
+]
 UnknownInputType: te.TypeAlias = t.Union[UnknownType, t.Dict[str, t.Any]]

--- a/packages/atproto_codegen/models/generator.py
+++ b/packages/atproto_codegen/models/generator.py
@@ -815,9 +815,11 @@ def _generate_record_type_database(lex_db: builder.BuiltRecordModels) -> None:
 
     unknown_record_type_hint_lines.append(']')
     unknown_record_type_pydantic_lines.append('], Field(discriminator="py_type")]')
+    unknown_record_type_pydantic_lines.append('UnknownType: te.TypeAlias = te.Annotated[')
     unknown_record_type_pydantic_lines.append(
-        "UnknownType: te.TypeAlias = t.Union[UnknownRecordTypePydantic, 'dot_dict.DotDictType']"
+        f"{_(4)}t.Union[UnknownRecordTypePydantic, 'dot_dict.DotDictType'], Field(union_mode='left_to_right')"
     )
+    unknown_record_type_pydantic_lines.append(']')
     unknown_record_type_pydantic_lines.append(
         'UnknownInputType: te.TypeAlias = t.Union[UnknownType, t.Dict[str, t.Any]]'
     )

--- a/packages/atproto_core/car/car.py
+++ b/packages/atproto_core/car/car.py
@@ -55,9 +55,9 @@ class CAR:
             # The first element of the CAR roots metadata array must be the CID of the most relevant Commit object.
             # For a generic export, this is the current (most recent) commit.
             # Additional CIDs may also be present in the roots array, with (for now) undefined meaning or order.
-            root: CID = CID.decode(roots[0])
+            root: CID = CID.from_decoded_bytes(roots[0])
         else:
             raise InvalidCARFile('Invalid CAR file. Expected at least one root.')
 
-        blocks = {CID.decode(cid): block for cid, block in blocks.items()}
+        blocks = {CID.from_decoded_bytes(cid): block for cid, block in blocks.items()}
         return cls(root=root, blocks=blocks)

--- a/packages/atproto_core/cid/cid.py
+++ b/packages/atproto_core/cid/cid.py
@@ -15,14 +15,29 @@ class Multihash:
     digest: bytes
 
 
-@dataclass(eq=False)
 class CID:
-    version: int
-    codec: int
-    hash: Multihash
+    """Content Identifier.
 
-    _stringified_form: t.Optional[str] = None
-    _raw_byte_form: t.Optional[str] = None
+    Note:
+        `version`, `codec`, and `hash` are decoded lazily on first access. Consumers that only
+        compare or stringify CIDs (the CAR decoding path, for one) never pay for the multihash.
+    """
+
+    __slots__ = ('_codec', '_hash', '_raw_byte_form', '_stringified_form', '_version')
+
+    def __init__(
+        self,
+        version: t.Optional[int] = None,
+        codec: t.Optional[int] = None,
+        hash: t.Optional[Multihash] = None,
+        _stringified_form: t.Optional[str] = None,
+        _raw_byte_form: t.Optional[bytes] = None,
+    ) -> None:
+        self._version = version
+        self._codec = codec
+        self._hash = hash
+        self._stringified_form = _stringified_form
+        self._raw_byte_form = _raw_byte_form
 
     @classmethod
     def decode(cls, value: t.Union[str, bytes]) -> 'CID':
@@ -47,12 +62,71 @@ class CID:
 
         return instance
 
+    @classmethod
+    def from_decoded_bytes(cls, value: bytes) -> 'CID':
+        """Wrap the binary form of a CID that the decoder it came from has already validated.
+
+        Skips the redundant :obj:`libipld.decode_cid` call that :obj:`CID.decode` performs.
+        """
+        return cls(_raw_byte_form=value)
+
+    def _encoded_form(self) -> t.Union[str, bytes]:
+        encoded = self._raw_byte_form if self._raw_byte_form is not None else self._stringified_form
+        if encoded is None:
+            raise ValueError('CID was built without an encoded form')
+
+        return encoded
+
+    def _decode_lazy_fields(self) -> None:
+        cid = libipld.decode_cid(self._encoded_form())
+
+        self._version = cid['version']
+        self._codec = cid['codec']
+        self._hash = Multihash(
+            code=cid['hash']['code'],
+            size=cid['hash']['size'],
+            digest=cid['hash']['digest'],
+        )
+
+    @property
+    def version(self) -> int:
+        """Get CID version."""
+        if self._version is None:
+            self._decode_lazy_fields()
+
+        return t.cast('int', self._version)
+
+    @property
+    def codec(self) -> int:
+        """Get CID codec."""
+        if self._codec is None:
+            self._decode_lazy_fields()
+
+        return t.cast('int', self._codec)
+
+    @property
+    def hash(self) -> Multihash:
+        """Get CID multihash."""
+        if self._hash is None:
+            self._decode_lazy_fields()
+
+        return t.cast('Multihash', self._hash)
+
     def encode(self) -> str:
         if self._stringified_form is not None:
             return self._stringified_form
 
+        if self._raw_byte_form is None:
+            raise ValueError('CID was built without an encoded form')
+
         self._stringified_form = libipld.encode_cid(self._raw_byte_form)
         return self._stringified_form
+
+    def __repr__(self) -> str:
+        return (
+            f'CID(version={self.version}, codec={self.codec}, hash={self.hash!r}, '
+            f'_stringified_form={self._stringified_form!r}, _raw_byte_form={self._raw_byte_form!r})'
+        )
 
     def __str__(self) -> str:
         return self.encode()

--- a/packages/atproto_firehose/models.py
+++ b/packages/atproto_firehose/models.py
@@ -55,8 +55,8 @@ def parse_frame_header(raw_header: dict) -> FrameHeader:
 
         frame_type = FrameType(header_op)
         if frame_type is FrameType.MESSAGE:
-            return get_or_create(raw_header, MessageFrameHeader)
-        return get_or_create(raw_header, ErrorFrameHeader)
+            return MessageFrameHeader(op=frame_type, t=raw_header.get('t'))
+        return ErrorFrameHeader(op=frame_type)
     except (ValueError, AtProtocolError) as e:
         raise FirehoseDecodingError('Invalid frame header') from e
 

--- a/tests/test_atproto_client/models/tests/test_unknown_type.py
+++ b/tests/test_atproto_client/models/tests/test_unknown_type.py
@@ -1,0 +1,77 @@
+"""Resolution of the ``UnknownType`` union.
+
+``UnknownType`` is a left-to-right union so that a known record does not also get built as a
+throwaway :obj:`DotDict`. These tests pin both halves of that: the fallback still happens for
+everything the models cannot describe, and it no longer happens for everything they can.
+"""
+
+import typing as t
+
+import pytest
+from atproto_client import models
+from atproto_client.models import dot_dict
+from atproto_client.models.dot_dict import DotDict
+
+#: CID of the DAG-CBOR block ``{'text': 'synthetic subject post'}``; no repo on the network holds it.
+_SUBJECT_CID = 'bafyreidnwt5s2u353exextusedas4nr77z5rhgzmg5j2swdadb7n65wxsy'
+
+_AUTHOR_DID = 'did:plc:aaaaaaaaaaaaaaaaaaaaaaaa'
+_SUBJECT_DID = 'did:plc:bbbbbbbbbbbbbbbbbbbbbbbb'
+
+_SUBJECT = {'cid': _SUBJECT_CID, 'uri': f'at://{_SUBJECT_DID}/app.bsky.feed.post/3aaaaaaaaaaac'}
+_LIKE = {'$type': 'app.bsky.feed.like', 'createdAt': '2026-01-01T00:00:00Z', 'subject': _SUBJECT}
+
+_COMMIT = {
+    '$type': 'network.bsky.jetstream.subscribeEvents#commit',
+    'collection': 'app.bsky.feed.like',
+    'did': _AUTHOR_DID,
+    'operation': 'create',
+    'rev': '3aaaaaaaaaaaa',
+    'rkey': '3aaaaaaaaaaab',
+    'seq': 1,
+    'time': '2026-01-01T00:00:00.000000Z',
+}
+
+
+def _parse_record(record: dict) -> t.Any:
+    commit = models.NetworkBskyJetstreamSubscribeEvents.Commit.model_validate({**_COMMIT, 'record': record})
+    return commit.record
+
+
+def test_known_record_resolves_to_model() -> None:
+    assert isinstance(_parse_record(_LIKE), models.AppBskyFeedLike.Record)
+
+
+def test_extended_known_record_resolves_to_model() -> None:
+    record = _parse_record({**_LIKE, 'via': None, 'custom': 'third-party client field'})
+
+    assert isinstance(record, models.AppBskyFeedLike.Record)
+    assert record['custom'] == 'third-party client field'
+
+
+@pytest.mark.parametrize(
+    'record',
+    [
+        pytest.param({'$type': 'com.example.thing', 'a': 1}, id='unknown_type'),
+        pytest.param({'a': 1}, id='no_type'),
+        pytest.param({'$type': 'com.example.thing', 'items': [{'a': 1}, {'b': 2}]}, id='nested_list'),
+        pytest.param({'$type': 'app.bsky.feed.like', 'createdAt': '2026-01-01T00:00:00Z'}, id='missing_required'),
+        pytest.param({'$type': 'app.bsky.feed.like', 'createdAt': 123, 'subject': _SUBJECT}, id='wrong_field_type'),
+    ],
+)
+def test_undescribable_record_falls_back_to_dot_dict(record: dict) -> None:
+    assert isinstance(_parse_record(record), DotDict)
+
+
+def test_known_record_does_not_build_a_throwaway_dot_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    created = []
+    original_init = DotDict.__init__
+
+    def spy(self: DotDict, data: dict) -> None:
+        created.append(data)
+        original_init(self, data)
+
+    monkeypatch.setattr(dot_dict.DotDict, '__init__', spy)
+
+    assert isinstance(_parse_record(_LIKE), models.AppBskyFeedLike.Record)
+    assert created == []

--- a/tests/test_atproto_core/car_builder.py
+++ b/tests/test_atproto_core/car_builder.py
@@ -1,0 +1,51 @@
+"""Builds CAR files in memory so tests never need captured network data."""
+
+import hashlib
+import typing as t
+
+import libipld
+
+_CID_V1 = b'\x01'
+_DAG_CBOR = b'\x71'
+_SHA2_256 = b'\x12\x20'  # multihash code 0x12, digest length 0x20
+
+
+def make_cid(block: bytes) -> bytes:
+    """Binary CIDv1 of a DAG-CBOR block: its sha2-256 digest."""
+    return _CID_V1 + _DAG_CBOR + _SHA2_256 + hashlib.sha256(block).digest()
+
+
+def _varint(value: int) -> bytes:
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        out.append(byte | 0x80 if value else byte)
+        if not value:
+            return bytes(out)
+
+
+def _cbor_cid_link(cid: bytes) -> bytes:
+    """DAG-CBOR tag 42 around the CID, identity-multibase prefixed."""
+    body = b'\x00' + cid
+    return b'\xd8\x2a\x58' + bytes([len(body)]) + body
+
+
+def _header(root: bytes) -> bytes:
+    """DAG-CBOR ``{'roots': [root], 'version': 1}``, keys in canonical order."""
+    return b'\xa2\x65roots\x81' + _cbor_cid_link(root) + b'\x67version\x01'
+
+
+def encode_car(blocks: t.Sequence[dict]) -> bytes:
+    """Encode blocks as a CARv1 file rooted at the first one."""
+    encoded = [libipld.encode_dag_cbor(block) for block in blocks]
+    cids = [make_cid(block) for block in encoded]
+
+    parts = [_header(cids[0])]
+    parts = [_varint(len(parts[0])), *parts]
+    for cid, block in zip(cids, encoded):
+        parts.append(_varint(len(cid) + len(block)))
+        parts.append(cid)
+        parts.append(block)
+
+    return b''.join(parts)

--- a/tests/test_atproto_core/test_cid.py
+++ b/tests/test_atproto_core/test_cid.py
@@ -1,5 +1,9 @@
+import libipld
+from atproto_core.car import CAR
 from atproto_core.cid import CID, CIDType
 from pydantic import BaseModel
+
+from .car_builder import encode_car, make_cid
 
 
 def test_cid_decode_str() -> None:
@@ -75,3 +79,34 @@ def test_cid_type_bytes() -> None:
 
     model_json = model.model_dump_json()
     assert model_json == f'{{"cid":"{model.cid}"}}'
+
+
+def test_cid_from_decoded_bytes_lazy_fields() -> None:
+    test_cid_bytes = make_cid(libipld.encode_dag_cbor({'text': 'synthetic block'}))
+    test_cid_str = libipld.encode_cid(test_cid_bytes)
+
+    cid = CID.from_decoded_bytes(test_cid_bytes)
+
+    assert cid._version is None  # not decoded until asked for
+    assert cid.version == 1
+    assert cid.codec == 113
+    assert cid.hash == CID.decode(test_cid_bytes).hash
+
+    assert cid.encode() == test_cid_str
+    assert cid == test_cid_str
+    assert cid == CID.decode(test_cid_bytes)
+    assert hash(cid) == hash(CID.decode(test_cid_bytes))
+
+
+def test_car_blocks_lookup_by_cid_and_str() -> None:
+    root_block = {'text': 'synthetic root block'}
+    child_block = {'text': 'synthetic child block'}
+    car = CAR.from_bytes(encode_car([root_block, child_block]))
+
+    assert len(car.blocks) == 2
+    assert car.root == libipld.encode_cid(make_cid(libipld.encode_dag_cbor(root_block)))
+
+    # a CID key must resolve both as itself and by its stringified form
+    for block_cid in car.blocks:
+        assert car.blocks[block_cid] in (root_block, child_block)
+        assert car.blocks[str(block_cid)] == car.blocks[block_cid]

--- a/tests/test_atproto_firehose/test_models.py
+++ b/tests/test_atproto_firehose/test_models.py
@@ -1,0 +1,47 @@
+"""Framing of decoded Firehose frames."""
+
+import libipld
+import pytest
+from atproto_firehose.exceptions import FirehoseDecodingError
+from atproto_firehose.models import (
+    ErrorFrame,
+    ErrorFrameHeader,
+    Frame,
+    FrameType,
+    MessageFrame,
+    MessageFrameHeader,
+)
+
+from .conftest import error_frame, message_frame
+
+
+def test_message_frame_header() -> None:
+    frame = Frame.from_bytes(message_frame(seq=1))
+
+    assert isinstance(frame, MessageFrame)
+    assert isinstance(frame.header, MessageFrameHeader)
+    assert frame.header.op is FrameType.MESSAGE
+    assert frame.operation is FrameType.MESSAGE
+    assert frame.is_message
+    assert not frame.is_error
+    assert frame.type == '#commit'
+
+
+def test_error_frame_header() -> None:
+    frame = Frame.from_bytes(error_frame('ConsumerTooSlow', 'stream consumer too slow'))
+
+    assert isinstance(frame, ErrorFrame)
+    assert isinstance(frame.header, ErrorFrameHeader)
+    assert frame.header.op is FrameType.ERROR
+    assert frame.operation is FrameType.ERROR
+    assert frame.is_error
+    assert not frame.is_message
+    assert frame.body.error == 'ConsumerTooSlow'
+    assert frame.body.message == 'stream consumer too slow'
+
+
+def test_unknown_operation_is_rejected() -> None:
+    raw = libipld.encode_dag_cbor({'op': 42}) + libipld.encode_dag_cbor({})
+
+    with pytest.raises(FirehoseDecodingError):
+        Frame.from_bytes(raw)


### PR DESCRIPTION
Jetstream 56k -> 111k events/s, Firehose 22.7k -> 31.1k frames/s. Same bytes in, byte-identical models out

### Results per stage

| Stage | Before | After | Speedup | Throughput after |
|---|---:|---:|---:|---:|
| *anchor:* `pydantic_core.from_json` (Rust) | 8.57 ms | 8.69 ms | 0.99x | 575k frame/s |
| **Jetstream** | | | | |
| `parse_frame` | 10.09 ms | 10.18 ms | 0.99x | 491k frame/s |
| `parse_subscribe_events_message` | 79.06 ms | **35.68 ms** | **2.22x** | 140k event/s |
| **FULL pipeline** | 89.02 ms | **45.06 ms** | **1.98x** | **111k event/s** |
| **Firehose** | | | | |
| `decode_dag_multi` (Rust) | 6.16 ms | 6.97 ms | 0.88x | 430k frame/s |
| `Frame.from_bytes` | 11.62 ms | 9.76 ms | 1.19x | 307k frame/s |
| `parse_subscribe_repos_message` | 28.72 ms | 26.71 ms | 1.08x | 112k msg/s |
| `libipld.decode_car` (Rust) | 44.54 ms | 45.01 ms | 0.99x | 66k CAR/s |
| `CAR.from_bytes` | 104.95 ms | **71.01 ms** | **1.48x** | 42k CAR/s |
| `CID.decode` | 2.56 ms | 2.43 ms | 1.06x | 907k CID/s |
| **FULL pipeline** | 132.41 ms | **96.38 ms** | **1.37x** | **31k frame/s** |

### How achieved 

1. **Stop building every record twice.** A smart union made pydantic build every known record as a throwaway `DotDict` too. Now left-to-right.
2. **Cheap string-format gate.** A no-op validator cost two Python frames and an ABC check per field, ~9x per event. Now one frame and a dict check.
3. **Lazy CID decoding.** We re-parsed bytes libipld had just parsed, for fields the hot path never reads. Once per CAR block.
