### PR TITLE
Deprecate `AtUri.http` in favor of the correctly named `AtUri.href`

### DIFF
--- a/packages/atproto_core/uri/uri.py
+++ b/packages/atproto_core/uri/uri.py
@@ -3,6 +3,8 @@ import typing as t
 import urllib.parse as urlparse
 from urllib.parse import urlencode
 
+import typing_extensions as te
+
 from atproto_core.exceptions import InvalidAtUriError
 
 # ref: https://github.com/bluesky-social/atproto/blob/a4af3494bd8263187bb3450193bcd2467ae6b788/packages/syntax/src/aturi.ts#L5C5-L5C98
@@ -79,9 +81,19 @@ class AtUri:
         return ''
 
     @property
-    def http(self) -> str:
-        """Convert instance to HTTP URI."""
+    def href(self) -> str:
+        """Get string representation of the URI."""
         return str(self)
+
+    @property
+    @te.deprecated('`AtUri.http` is a misnomer of `AtUri.href`. It never returns an HTTP URI. Use `AtUri.href`.')
+    def http(self) -> str:
+        """Get string representation of the URI.
+
+        .. deprecated::
+            Use :obj:`AtUri.href` instead.
+        """
+        return self.href
 
     @property
     def search(self) -> str:

--- a/tests/test_atproto_core/test_uri.py
+++ b/tests/test_atproto_core/test_uri.py
@@ -86,3 +86,18 @@ def test_at_uri_from_str_roundtrip(valid_at_uri: str) -> None:
     """Test str -> AtUri.from_str -> str roundtrip with valid data."""
     round_tripped_at_uri = str(AtUri.from_str(valid_at_uri))
     assert round_tripped_at_uri.startswith(valid_at_uri)  # trailing slash is okay
+
+
+def test_at_uri_href() -> None:
+    test_uri = 'at://did:plc:poqvcn9iqfkgukdvqvb2qzba/app.bsky.feed.post/1jlmwihiomm9m'
+
+    at_uri = AtUri.from_str(test_uri)
+    assert at_uri.href == test_uri
+    assert at_uri.href == str(at_uri)
+
+
+def test_at_uri_http_is_deprecated() -> None:
+    at_uri = AtUri.from_str('at://did:plc:poqvcn9iqfkgukdvqvb2qzba/app.bsky.feed.post/1jlmwihiomm9m')
+
+    with pytest.deprecated_call():
+        assert at_uri.http == at_uri.href


### PR DESCRIPTION
closes https://github.com/MarshalX/atproto/issues/664