### PR TITLE
Update lexicons: add app.bsky.feed.defs#knownLikers (1 changed)

### DIFF
--- a/lexicons/app.bsky.feed.defs.json
+++ b/lexicons/app.bsky.feed.defs.json
@@ -52,7 +52,29 @@
         "threadMuted": { "type": "boolean" },
         "replyDisabled": { "type": "boolean" },
         "embeddingDisabled": { "type": "boolean" },
-        "pinned": { "type": "boolean" }
+        "pinned": { "type": "boolean" },
+        "knownLikers": {
+          "description": "This property is present only in selected cases, as an optimization.",
+          "type": "ref",
+          "ref": "#knownLikers"
+        }
+      }
+    },
+    "knownLikers": {
+      "type": "object",
+      "description": "The post's likers whom you also follow",
+      "required": ["count", "actors"],
+      "properties": {
+        "count": { "type": "integer" },
+        "actors": {
+          "type": "array",
+          "minLength": 0,
+          "maxLength": 5,
+          "items": {
+            "type": "ref",
+            "ref": "app.bsky.actor.defs#profileViewBasic"
+          }
+        }
       }
     },
     "threadContext": {

--- a/packages/atproto_client/models/app/bsky/feed/defs.py
+++ b/packages/atproto_client/models/app/bsky/feed/defs.py
@@ -58,6 +58,9 @@ class ViewerState(base.ModelBase):
 
     bookmarked: t.Optional[bool] = None  #: Bookmarked.
     embedding_disabled: t.Optional[bool] = None  #: Embedding disabled.
+    known_likers: t.Optional['models.AppBskyFeedDefs.KnownLikers'] = (
+        None  #: This property is present only in selected cases, as an optimization.
+    )
     like: t.Optional[string_formats.AtUri] = None  #: Like.
     pinned: t.Optional[bool] = None  #: Pinned.
     reply_disabled: t.Optional[bool] = None  #: Reply disabled.
@@ -66,6 +69,17 @@ class ViewerState(base.ModelBase):
 
     py_type: t.Literal['app.bsky.feed.defs#viewerState'] = Field(
         default='app.bsky.feed.defs#viewerState', alias='$type', frozen=True
+    )
+
+
+class KnownLikers(base.ModelBase):
+    """Definition model for :obj:`app.bsky.feed.defs`. The post's likers whom you also follow."""
+
+    actors: t.List['models.AppBskyActorDefs.ProfileViewBasic'] = Field(min_length=0, max_length=5)  #: Actors.
+    count: int  #: Count.
+
+    py_type: t.Literal['app.bsky.feed.defs#knownLikers'] = Field(
+        default='app.bsky.feed.defs#knownLikers', alias='$type', frozen=True
     )
 
 


### PR DESCRIPTION
Automated update of the vendored lexicons and everything generated from them.

Fetched from:

- [`bluesky-social/atproto@c400731`](https://github.com/bluesky-social/atproto/commit/c400731969775d220ade8cc55b0892018bdf8514) (2026-08-20T13:33:59Z)
- [`bluesky-social/jetstream@11e399d`](https://github.com/bluesky-social/jetstream/commit/11e399d402cea54df8b6696e35020a3147a52ed6) (2026-08-12T16:51:26Z)

## Lexicon changes

### New defs

- `app.bsky.feed.defs#knownLikers`

### New fields

- `app.bsky.feed.defs#viewerState.knownLikers`