### PR TITLE
Fix clones losing transport config and authentication, and add `RateLimitExceededError`

### DIFF
--- a/docs/source/guides/authentication.md
+++ b/docs/source/guides/authentication.md
@@ -126,8 +126,23 @@ async def on_session_change(event: SessionEvent, session: Session) -> None:
 
 The async client accepts both synchronous and asynchronous callbacks.
 
-:::{warning}
-Register a plain function or a coroutine function. A **bound method** or a callable object is accepted without complaint and then never invoked, because the dispatcher only recognises the two function forms. If your callback needs state, close over it rather than hanging it off `self`.
+Anything callable works: a plain function, a coroutine function, a bound method, a `functools.partial`, or an object with a `__call__`. So a callback that needs state can live on the class that holds it:
+
+```python
+class Bot:
+    def __init__(self) -> None:
+        self.client = Client()
+        self.client.on_session_change(self._save_session)
+
+    def _save_session(self, event: SessionEvent, session: Session) -> None:
+        if event in (SessionEvent.CREATE, SessionEvent.REFRESH):
+            save_session(session.export())
+```
+
+Registering something that is not callable raises `TypeError` right away.
+
+:::{note}
+A callable *object* whose `__call__` is `async` is registered as a synchronous callback, because `inspect.iscoroutinefunction` does not see through `__call__`. Use an `async def` method for an asynchronous callback with state.
 :::
 
 The three events:

--- a/docs/source/guides/error-handling.md
+++ b/docs/source/guides/error-handling.md
@@ -25,6 +25,7 @@ AtProtocolError
 │   ├── UnauthorizedError
 │   ├── BadRequestError
 │   └── RequestException
+│       └── RateLimitExceededError
 ├── LoginRequiredError
 ├── InvalidAtUriError
 ├── InvalidNsidError
@@ -37,6 +38,9 @@ AtProtocolError
 
 [RequestErrorBase](#atproto_client.exceptions.RequestErrorBase)
 : The base of everything that comes back from an HTTP request. Carries a `.response`.
+
+[RateLimitExceededError](#atproto_client.exceptions.RateLimitExceededError)
+: A 429. Subclasses `RequestException`, so an existing `except RequestException` still catches it.
 
 [LoginRequiredError](#atproto_client.exceptions.LoginRequiredError)
 : Raised locally, before any request, by a method that needs a session when there is none. See [Authentication](authentication.md).
@@ -72,16 +76,16 @@ except RequestErrorBase as e:
 
 A non-2xx response is turned into an exception by status code:
 
-| Status            | Exception                                                         |
-| ----------------- | ----------------------------------------------------------------- |
-| 400               | [BadRequestError](#atproto_client.exceptions.BadRequestError)     |
-| 401, 403          | [UnauthorizedError](#atproto_client.exceptions.UnauthorizedError) |
-| 409, 413, 502     | [NetworkError](#atproto_client.exceptions.NetworkError)           |
-| any other non-2xx | [RequestException](#atproto_client.exceptions.RequestException)   |
+| Status            | Exception                                                                   |
+| ----------------- | --------------------------------------------------------------------------- |
+| 400               | [BadRequestError](#atproto_client.exceptions.BadRequestError)               |
+| 401, 403          | [UnauthorizedError](#atproto_client.exceptions.UnauthorizedError)           |
+| 409, 413, 502     | [NetworkError](#atproto_client.exceptions.NetworkError)                     |
+| 429               | [RateLimitExceededError](#atproto_client.exceptions.RateLimitExceededError) |
+| any other non-2xx | [RequestException](#atproto_client.exceptions.RequestException)             |
 
 Note what this means in practice:
 
-- **429 is a `RequestException`**, not its own class. Rate limiting is detected by the status code and the headers, not the exception type.
 - **409, 413, and 502 are `NetworkError`**, which is otherwise the transport-failure class. A swap-commit conflict (409) and a payload that is too large (413) land there because they are worth retrying the same way a 502 is.
 - `UnauthorizedError` covers both "your token is wrong" (401) and "your token is fine but does not grant this" (403). The `error` name in the body separates them. A `Bad token scope` from a chat call means the app password lacks the direct-message grant.
 
@@ -126,17 +130,22 @@ Fine-tuning is documented in the [HTTPX timeout guide](https://www.python-httpx.
 
 ## Rate limits
 
-Rate-limited responses come back as 429, which means a [RequestException](#atproto_client.exceptions.RequestException). The budget is in the response headers, lowercased:
+Rate-limited responses come back as 429, which is a [RateLimitExceededError](#atproto_client.exceptions.RateLimitExceededError). It reads the budget out of the response headers for you:
 
 ```python
-from atproto.exceptions import RequestException
+from atproto.exceptions import RateLimitExceededError
 
 try:
     ...
-except RequestException as e:
-    if e.response and e.response.status_code == 429:
-        print('Reset at:', e.response.headers.get('ratelimit-reset'))
+except RateLimitExceededError as e:
+    print('Reset at:', e.reset_at)  # datetime in UTC, or None
 ```
+
+`limit`, `remaining` and `reset_at` come from `ratelimit-limit`, `ratelimit-remaining` and `ratelimit-reset`; `policy` from `ratelimit-policy`; `retry_after` from `retry-after`. Each is `None` when the server did not send that header, and services differ in which ones they send: the PDS sends the `ratelimit-*` family, while the [Jetstream archive](jetstream.md) answers a spent byte quota with `retry-after`. The raw headers are still on `e.response.headers`.
+
+`retry_after` is seconds to wait, as a float. HTTP allows the header to carry either a number of seconds or a date; both come back as seconds from now, never negative.
+
+`RateLimitExceededError` subclasses [RequestException](#atproto_client.exceptions.RequestException), which is what a 429 was raised as before, so code that already catches `RequestException` keeps working.
 
 The limits that bite hardest are per-handle rather than per-request: `createSession` allows 30 requests per 5 minutes and 300 per day, so a script that constructs a fresh client and logs in on every tick will exhaust it. Keep one client alive, or reuse the session string. See [Authentication](authentication.md).
 
@@ -144,7 +153,7 @@ Current limits are published at [bsky.network/docs/rate-limits](https://bsky.net
 
 ## Where each package's exceptions live
 
-Every package defines its own module. `atproto.exceptions` re-exports all of them **except `atproto_jetstream.exceptions`**, which you have to import from its own package.
+Every package defines its own module, and `atproto.exceptions` re-exports all of them. Importing from `atproto.exceptions` always works; the per-package modules are listed here so you know where each name comes from.
 
 `atproto_core.exceptions`
 : `AtProtocolError` and the parsing failures of the core primitives: `InvalidNsidError`, `InvalidAtUriError`, `InvalidCARFile`, `DAGCBORDecodingError`.
@@ -170,5 +179,5 @@ Every package defines its own module. `atproto.exceptions` re-exports all of the
 `atproto_firehose.exceptions`
 : `FirehoseError` and `FirehoseDecodingError`, aliases of the two above, kept for backward compatibility.
 
-`atproto_jetstream.exceptions` (not re-exported; import it directly)
+`atproto_jetstream.exceptions`
 : `JetstreamError`, `JetstreamDecodingError`, plus two conditions worth handling separately: `JetstreamConsumerTooSlowError` (the server dropped you for falling behind) and `JetstreamCursorTooOldError` (your cursor is below the server's retention floor).

--- a/docs/source/guides/http-and-transport.md
+++ b/docs/source/guides/http-and-transport.md
@@ -52,8 +52,8 @@ Three settings are worth knowing about:
 `proxy` / `mounts`
 : An HTTP proxy in the ordinary networking sense. Unrelated to `atproto-proxy`, which is service routing inside the protocol. See [Proxies and labelers](proxies-and-labelers.md).
 
-:::{warning}
-A [clone](proxies-and-labelers.md#cloning), which is what `with_proxy` and `with_labelers` return, builds a **fresh** `Request` with default arguments. Your timeout, transport and proxy do not carry over. Give a proxied client its own configured `Request` if it needs one.
+:::{note}
+A [clone](proxies-and-labelers.md#cloning), which is what `with_proxy` and `with_labelers` return, is constructed with the same keyword arguments as the original, so your timeout, transport and proxy carry over. It still opens its own `httpx` client, and with it its own connection pool.
 :::
 
 ```{literalinclude} ../../../examples/advanced_usage/custom_request.py

--- a/docs/source/guides/models.md
+++ b/docs/source/guides/models.md
@@ -224,7 +224,7 @@ The first `models.AppBskyFeedPost` resolves the alias through `models.ids`, impo
 You rarely need to know this, except in two cases:
 
 - The import cost is paid on first *use*, not at import time. To pay it up front instead, before forking worker processes or to keep it out of your first request's latency, call [load_models](#atproto_client.models.models_loader.load_models).
-- `from atproto import models` is the way in. `from atproto.models import AppBskyFeedPost` does **not** work, because `atproto.models` is a re-exported attribute, not a submodule, so there is nothing for the import system to find. `from atproto_client.models import AppBskyFeedPost` does work, through the same `__getattr__`.
+- `from atproto import models`, `from atproto.models import AppBskyFeedPost` and `from atproto_client.models import AppBskyFeedPost` all resolve to the same lazily-loaded package, through the same `__getattr__`.
 
 ```python
 from atproto_client.models.models_loader import load_models

--- a/docs/source/guides/proxies-and-labelers.md
+++ b/docs/source/guides/proxies-and-labelers.md
@@ -76,13 +76,16 @@ What a clone copies:
 
 - **The request's additional headers.** A fresh dict, so configuring the clone does not touch the original's headers.
 - **The additional-header sources.** The list of callbacks is copied; the callbacks themselves are shared.
+- **The configuration of the underlying `httpx` client.** Every keyword argument the original [Request](#atproto_client.request.Request) was constructed with, so a timeout, transport or proxy you set carries over.
 
-What a clone does **not** share is the underlying `httpx` client: `clone()` constructs a new [Request](#atproto_client.request.Request) of the same class with default arguments. A timeout or transport you configured on the original does **not** carry over, and each clone holds its own connection pool that you should `close()` separately. If you need custom transport settings on a proxied client, build it with its own `Request` rather than cloning.
+What a clone does **not** share is the `httpx` client itself. Each one opens its own connection pool, so `close()` it separately. See [HTTP and transport](http-and-transport.md).
 
 Sharing the session is the important half. A token refresh triggered by any one of the clones updates the session all of them are using, and fires the callbacks registered on any of them. Logging in once and fanning out into several proxied clients is the intended pattern.
 
-:::{warning}
-Clone *after* logging in. A clone taken before login gets `_session = None` and no `Authorization` header source, and the login that happens later on the original never reaches it, so every call from that clone goes out unauthenticated. It also inherits the base URL as it stands, so cloning after login is what gets it the PDS endpoint discovered during login rather than the URL you constructed the client with. See [Authentication](authentication.md).
+Because the session lives in the shared dispatcher rather than on the client, the order does not matter: a clone taken *before* `login()` picks up the session the original creates later, and authenticates from that point on.
+
+:::{attention}
+A clone inherits the base URL as it stands at the moment you clone. Login repoints the client at the PDS discovered in the DID document, so a clone taken before login keeps the URL you constructed the client with. Cloning after login is still the simpler thing to do. See [Authentication](authentication.md).
 :::
 
 ## Headers, and who wins

--- a/examples/advanced_usage/error_handling.py
+++ b/examples/advanced_usage/error_handling.py
@@ -2,6 +2,7 @@ from atproto import Client
 from atproto.exceptions import (
     BadRequestError,
     InvokeTimeoutError,
+    RateLimitExceededError,
     RequestErrorBase,
     UnauthorizedError,
 )
@@ -28,6 +29,10 @@ def main() -> None:
         client.login(USERNAME, PASSWORD)
     except UnauthorizedError as e:
         print('Login rejected:', describe(e))
+        return
+    except RateLimitExceededError as e:
+        # createSession is rate limited by handle: 30/5 min, 300/day
+        print('Too many logins. Retry at:', e.reset_at)
         return
     except InvokeTimeoutError:
         print('The PDS did not answer in time.')

--- a/packages/atproto/exceptions.py
+++ b/packages/atproto/exceptions.py
@@ -3,6 +3,7 @@ from atproto_core.exceptions import *
 from atproto_crypto.exceptions import *
 from atproto_firehose.exceptions import *
 from atproto_identity.exceptions import *
+from atproto_jetstream.exceptions import *
 from atproto_lexicon.exceptions import *
 from atproto_server.exceptions import *
 from atproto_subscription.exceptions import *

--- a/packages/atproto/models.py
+++ b/packages/atproto/models.py
@@ -1,0 +1,15 @@
+"""Alias of :mod:`atproto_client.models` as a real submodule of :mod:`atproto`.
+
+``from atproto import models`` and ``from atproto.models import AppBskyFeedPost`` both resolve
+to the very same module object.
+"""
+
+import sys
+import typing as t
+
+from atproto_client import models
+
+if t.TYPE_CHECKING:
+    from atproto_client.models import *  # noqa: F403
+
+sys.modules[__name__] = models

--- a/packages/atproto_client/client/base.py
+++ b/packages/atproto_client/client/base.py
@@ -59,6 +59,10 @@ def _handle_base_url(base_url: t.Optional[str] = None) -> str:
 
 
 class _ClientCommonMethodsMixin:
+    def _get_clone_kwargs(self) -> t.Dict[str, t.Any]:
+        """Return the constructor arguments a clone must be built with, on top of the base URL and request."""
+        return {}
+
     def clone(self) -> te.Self:
         """Clone the client instance.
 
@@ -67,7 +71,7 @@ class _ClientCommonMethodsMixin:
         Returns:
             Cloned client instance.
         """
-        return type(self)(base_url=self._base_url, request=self.request.clone())
+        return type(self)(base_url=self._base_url, request=self.request.clone(), **self._get_clone_kwargs())
 
     def update_base_url(self, base_url: t.Optional[str] = None) -> None:
         """Update XRPC base URL.

--- a/packages/atproto_client/client/methods_mixin/headers.py
+++ b/packages/atproto_client/client/methods_mixin/headers.py
@@ -25,15 +25,15 @@ class HeadersConfigurationMethodsMixin:
 
         Used to customize atproto proxy and set of labeler services.
 
+        Note:
+            The clone shares the session and its dispatcher with the original, so it stays
+            authenticated even when it is created before the first login.
+
         Returns:
             Cloned client instance.
         """
         cloned_client = super().clone()
-
-        # share the same objects to avoid conflicts with session changes
         cloned_client.me = self.me
-        cloned_client._session = self._session
-        cloned_client._session_dispatcher = self._session_dispatcher
 
         return cloned_client
 

--- a/packages/atproto_client/client/methods_mixin/session.py
+++ b/packages/atproto_client/client/methods_mixin/session.py
@@ -90,13 +90,23 @@ class AsyncSessionDispatchMixin:
 
 
 class SessionMethodsMixin(TimeMethodsMixin):
-    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+    def __init__(self, *args: t.Any, session_dispatcher: t.Optional[SessionDispatcher] = None, **kwargs: t.Any) -> None:
         super().__init__(*args, **kwargs)
-        self._session: t.Optional[Session] = None
-        self._session_dispatcher = SessionDispatcher()
+        self._session_dispatcher = session_dispatcher or SessionDispatcher()
+        self._register_auth_headers_source()
+
+    @property
+    def _session(self) -> t.Optional[Session]:
+        return self._session_dispatcher.session
+
+    def _get_clone_kwargs(self) -> t.Dict[str, t.Any]:
+        return {**super()._get_clone_kwargs(), 'session_dispatcher': self._session_dispatcher}
 
     def _register_auth_headers_source(self) -> None:
-        self.request.add_additional_headers_source(self._get_access_auth_headers)
+        request = self.request
+        source = self._session_dispatcher.get_auth_headers
+        if source not in request._additional_header_sources:  # a clone inherits it from its original
+            request.add_additional_headers_source(source)
 
     def _should_refresh_session(self) -> bool:
         if not self._session or not self._session.access_jwt_payload or not self._session.access_jwt_payload.exp:
@@ -108,24 +118,24 @@ class SessionMethodsMixin(TimeMethodsMixin):
         return self.get_current_time() > expired_at
 
     def _set_or_update_session(self, session: SessionResponse, pds_endpoint: str) -> 'Session':
-        if not self._session:
-            self._session = Session(
+        current_session = self._session
+        if current_session is None:
+            current_session = Session(
                 access_jwt=session.access_jwt,
                 refresh_jwt=session.refresh_jwt,
                 did=session.did,
                 handle=session.handle,
                 pds_endpoint=pds_endpoint,
             )
-            self._session_dispatcher.set_session(self._session)
-            self._register_auth_headers_source()
+            self._session_dispatcher.set_session(current_session)
         else:
-            self._session.access_jwt = session.access_jwt
-            self._session.refresh_jwt = session.refresh_jwt
-            self._session.did = session.did
-            self._session.handle = session.handle
-            self._session.pds_endpoint = pds_endpoint
+            current_session.access_jwt = session.access_jwt
+            current_session.refresh_jwt = session.refresh_jwt
+            current_session.did = session.did
+            current_session.handle = session.handle
+            current_session.pds_endpoint = pds_endpoint
 
-        return self._session
+        return current_session
 
     def _set_session_common(self, session: SessionResponse, current_pds: str) -> Session:
         pds_endpoint = get_session_pds_endpoint(session)
@@ -138,16 +148,10 @@ class SessionMethodsMixin(TimeMethodsMixin):
         return self._set_or_update_session(session, pds_endpoint)
 
     def _get_access_auth_headers(self) -> t.Dict[str, str]:
-        if not self._session:
-            return {}
-
-        return {'Authorization': f'Bearer {self._session.access_jwt}'}
+        return self._session_dispatcher.get_auth_headers()
 
     def _get_refresh_auth_headers(self) -> t.Dict[str, str]:
-        if not self._session:
-            return {}
-
-        return {'Authorization': f'Bearer {self._session.refresh_jwt}'}
+        return self._session_dispatcher.get_refresh_auth_headers()
 
     def _update_pds_endpoint(self, pds_endpoint: str) -> None:
         self.update_base_url(pds_endpoint)

--- a/packages/atproto_client/client/session.py
+++ b/packages/atproto_client/client/session.py
@@ -47,14 +47,35 @@ class SessionDispatcher:
         self._on_session_change_callbacks: t.List[SessionChangeCallback] = []
         self._on_session_change_async_callbacks: t.List[AsyncSessionChangeCallback] = []
 
+    @property
+    def session(self) -> t.Optional['Session']:
+        """Session the dispatcher holds. Shared by every client cloned from the same original."""
+        return self._session
+
     def set_session(self, session: 'Session') -> None:
         self._session = session
+
+    def get_auth_headers(self) -> t.Dict[str, str]:
+        """Build the ``Authorization`` header from the access token. Empty when there is no session."""
+        if not self._session:
+            return {}
+
+        return {'Authorization': f'Bearer {self._session.access_jwt}'}
+
+    def get_refresh_auth_headers(self) -> t.Dict[str, str]:
+        """Build the ``Authorization`` header from the refresh token. Empty when there is no session."""
+        if not self._session:
+            return {}
+
+        return {'Authorization': f'Bearer {self._session.refresh_jwt}'}
 
     def on_session_change(self, callback: t.Union['AsyncSessionChangeCallback', 'SessionChangeCallback']) -> None:
         if inspect.iscoroutinefunction(callback):
             self._on_session_change_async_callbacks.append(callback)
-        elif inspect.isfunction(callback):
-            self._on_session_change_callbacks.append(callback)
+        elif callable(callback):
+            self._on_session_change_callbacks.append(t.cast('SessionChangeCallback', callback))
+        else:
+            raise TypeError(f'Session change callback must be callable, got {type(callback).__name__}')
 
     def dispatch_session_change(self, event: SessionEvent) -> None:
         self._call_on_session_change_callbacks(event)

--- a/packages/atproto_client/exceptions.py
+++ b/packages/atproto_client/exceptions.py
@@ -1,4 +1,7 @@
+import math
 import typing as t
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 
 from atproto_core.exceptions import AtProtocolError
 
@@ -41,6 +44,14 @@ class ModelFieldNotFoundError(ModelError): ...
 
 
 class RequestErrorBase(AtProtocolError):
+    """Base of every error that comes out of an HTTP request.
+
+    Note:
+        :attr:`response` is :obj:`None` when the failure happened before a response arrived,
+        which is the case for every transport-level error (:class:`NetworkError` and
+        :class:`InvokeTimeoutError` raised from an underlying HTTPX exception).
+    """
+
     def __init__(self, response: t.Optional['Response'] = None) -> None:
         self.response: t.Optional[Response] = response
 
@@ -54,10 +65,20 @@ class RequestErrorBase(AtProtocolError):
         return f'{self.response.status_code} {details}' if details else str(self.response.status_code)
 
 
-class NetworkError(RequestErrorBase): ...
+class NetworkError(RequestErrorBase):
+    """Transport failure, or a status code that is worth retrying the same way (409, 413, 502).
+
+    Note:
+        :attr:`~RequestErrorBase.response` is :obj:`None` when raised from a transport failure.
+    """
 
 
-class InvokeTimeoutError(NetworkError): ...
+class InvokeTimeoutError(NetworkError):
+    """The request did not complete within the timeout of the underlying HTTP client.
+
+    Note:
+        :attr:`~RequestErrorBase.response` is always :obj:`None`.
+    """
 
 
 class UnauthorizedError(RequestErrorBase): ...
@@ -67,6 +88,94 @@ class RequestException(RequestErrorBase): ...
 
 
 class BadRequestError(RequestErrorBase): ...
+
+
+class RateLimitExceededError(RequestException):
+    """The server answered with 429. The remaining budget is exposed as attributes.
+
+    Note:
+        Inherits :class:`RequestException`, which is what a 429 used to be raised as.
+
+    Example:
+        >>> from atproto.exceptions import RateLimitExceededError
+        >>>
+        >>> try:
+        >>>     client.send_post(text='Hello')
+        >>> except RateLimitExceededError as e:
+        >>>     print('Retry at:', e.reset_at)
+    """
+
+    @property
+    def limit(self) -> t.Optional[int]:
+        """Number of requests the policy allows in the current window (``ratelimit-limit``)."""
+        return self._get_int_header('ratelimit-limit')
+
+    @property
+    def remaining(self) -> t.Optional[int]:
+        """Number of requests left in the current window (``ratelimit-remaining``)."""
+        return self._get_int_header('ratelimit-remaining')
+
+    @property
+    def reset_at(self) -> t.Optional[datetime]:
+        """UTC time at which the current window resets (``ratelimit-reset``)."""
+        timestamp = self._get_int_header('ratelimit-reset')
+        if timestamp is None:
+            return None
+
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+    @property
+    def policy(self) -> t.Optional[str]:
+        """Policy the limit comes from, e.g. ``100;w=300`` (``ratelimit-policy``)."""
+        return self._get_header('ratelimit-policy')
+
+    @property
+    def retry_after(self) -> t.Optional[float]:
+        """Seconds to wait before retrying (``retry-after``), or :obj:`None` when not usable.
+
+        Note:
+            The header carries either a number of seconds or an HTTP-date. Both are returned as
+            seconds from now, never negative. Not every service sends it; prefer :attr:`reset_at`
+            when it is absent.
+        """
+        value = self._get_header('retry-after')
+        if value is None:
+            return None
+
+        try:
+            delay = float(value)
+        except ValueError:
+            return self._seconds_until_http_date(value)
+
+        return max(delay, 0.0) if math.isfinite(delay) else None
+
+    @staticmethod
+    def _seconds_until_http_date(value: str) -> t.Optional[float]:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError):  # 3.9 raises TypeError where later versions raise ValueError
+            return None
+
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+
+        return max((retry_at - datetime.now(timezone.utc)).total_seconds(), 0.0)
+
+    def _get_header(self, name: str) -> t.Optional[str]:
+        if self.response is None:
+            return None
+
+        return self.response.headers.get(name)
+
+    def _get_int_header(self, name: str) -> t.Optional[int]:
+        value = self._get_header(name)
+        if value is None:
+            return None
+
+        try:
+            return int(value)
+        except ValueError:
+            return None
 
 
 class LoginRequiredError(AtProtocolError):

--- a/packages/atproto_client/request.py
+++ b/packages/atproto_client/request.py
@@ -104,6 +104,8 @@ def _handle_response(response: httpx.Response) -> httpx.Response:
         raise exceptions.UnauthorizedError(error_response)
     if response.status_code == 400:
         raise exceptions.BadRequestError(error_response)
+    if response.status_code == 429:
+        raise exceptions.RateLimitExceededError(error_response)
     if response.status_code in {409, 413, 502}:
         raise exceptions.NetworkError(error_response)
 
@@ -169,15 +171,24 @@ class RequestBase:
         """
         self._additional_headers[header_name] = header_value
 
+    def _new_instance(self) -> te.Self:
+        """Build an empty instance of this class configured the same way as this one."""
+        return type(self)()
+
     def clone(self) -> te.Self:
         """Clone the client instance.
 
         Used to customize atproto proxy and set of labeler services.
 
+        Note:
+            The clone keeps the configuration of the underlying HTTP client (timeouts, transport,
+            proxies, and anything else passed at construction), but opens its own connection pool.
+            Close it separately.
+
         Returns:
             Cloned client instance.
         """
-        cloned_request = type(self)()
+        cloned_request = self._new_instance()
 
         cloned_request._additional_headers = self._additional_headers.copy()
         cloned_request._additional_header_sources = self._additional_header_sources.copy()
@@ -194,7 +205,11 @@ class Request(RequestBase):
 
     def __init__(self, **kwargs: t.Any) -> None:
         super().__init__()
+        self._client_kwargs = kwargs
         self._client = httpx.Client(follow_redirects=True, **kwargs)
+
+    def _new_instance(self) -> te.Self:
+        return type(self)(**self._client_kwargs)
 
     def _send_request(self, method: str, url: str, **kwargs: t.Any) -> httpx.Response:
         headers = self.get_headers(kwargs.pop('headers', None))
@@ -225,7 +240,11 @@ class AsyncRequest(RequestBase):
 
     def __init__(self, **kwargs: t.Any) -> None:
         super().__init__()
+        self._client_kwargs = kwargs
         self._client = httpx.AsyncClient(follow_redirects=True, **kwargs)
+
+    def _new_instance(self) -> te.Self:
+        return type(self)(**self._client_kwargs)
 
     async def _send_request(self, method: str, url: str, **kwargs: t.Any) -> httpx.Response:
         headers = self.get_headers(kwargs.pop('headers', None))

--- a/packages/atproto_jetstream/archive/downloader.py
+++ b/packages/atproto_jetstream/archive/downloader.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from atproto_client.client.async_raw import AsyncClientRaw
 from atproto_client.client.raw import ClientRaw
-from atproto_client.exceptions import RequestErrorBase
+from atproto_client.exceptions import RateLimitExceededError
 
 from atproto_jetstream.archive.planner import WorkUnit
 from atproto_jetstream.archive.segment import SegmentEvent, decode_block, read_sealed_header
@@ -20,8 +20,6 @@ _HEADER_LEN = 256
 _BLOCK_LENGTH_PREFIX = 8
 
 DEFAULT_BLOCK_CONCURRENCY = 4
-
-_TOO_MANY_REQUESTS = 429
 
 #: Retry-After can be absent or unparseable; back off anyway rather than hammering the quota.
 _DEFAULT_RETRY_AFTER_SEC = 5.0
@@ -40,20 +38,14 @@ def quota_retry_after(exception: BaseException) -> t.Optional[float]:
     Returns:
         :obj:`float`: Delay to honour, or :obj:`None` if this was not a quota rejection.
     """
-    if not isinstance(exception, RequestErrorBase) or not exception.args:
+    if not isinstance(exception, RateLimitExceededError):
         return None
 
-    response = exception.args[0]
-    if getattr(response, 'status_code', None) != _TOO_MANY_REQUESTS:
-        return None
-
-    headers = getattr(response, 'headers', None) or {}
-    try:
-        delay = float(headers.get('retry-after', _DEFAULT_RETRY_AFTER_SEC))
-    except (TypeError, ValueError):
+    delay = exception.retry_after
+    if delay is None:
         delay = _DEFAULT_RETRY_AFTER_SEC
 
-    return min(max(delay, 0.0), _MAX_RETRY_AFTER_SEC)
+    return min(delay, _MAX_RETRY_AFTER_SEC)
 
 
 class ByteMeter:

--- a/tests/test_atproto/test_exceptions.py
+++ b/tests/test_atproto/test_exceptions.py
@@ -1,0 +1,37 @@
+import importlib
+import importlib.util
+import inspect
+import pkgutil
+import typing as t
+
+import atproto
+import atproto.exceptions
+import pytest
+
+
+def _exception_modules() -> t.List[str]:
+    """Every ``atproto_*.exceptions`` module that ships with the SDK."""
+    packages = [
+        module.name
+        for module in pkgutil.iter_modules()
+        if module.ispkg and module.name.startswith('atproto_') and not module.name.endswith(('_cli', '_codegen'))
+    ]
+
+    return [f'{package}.exceptions' for package in packages if importlib.util.find_spec(f'{package}.exceptions')]
+
+
+@pytest.mark.parametrize('module_name', _exception_modules())
+def test_every_exception_is_re_exported(module_name: str) -> None:
+    module = importlib.import_module(module_name)
+
+    for name, value in vars(module).items():
+        if name.startswith('_') or not inspect.isclass(value) or not issubclass(value, BaseException):
+            continue
+
+        assert getattr(atproto.exceptions, name, None) is value, f'{module_name}.{name} is not in atproto.exceptions'
+
+
+def test_jetstream_exceptions_are_re_exported() -> None:
+    from atproto_jetstream.exceptions import JetstreamCursorTooOldError
+
+    assert atproto.exceptions.JetstreamCursorTooOldError is JetstreamCursorTooOldError

--- a/tests/test_atproto/test_models.py
+++ b/tests/test_atproto/test_models.py
@@ -1,0 +1,16 @@
+import atproto
+import atproto.models
+import atproto_client.models
+from atproto.models import AppBskyFeedPost, ids
+
+
+def test_models_is_importable_as_a_submodule() -> None:
+    assert AppBskyFeedPost.Record.model_fields
+    assert ids.AppBskyFeedPost == 'app.bsky.feed.post'
+
+
+def test_models_submodule_is_the_models_package() -> None:
+    from atproto import models
+
+    assert atproto.models is atproto_client.models
+    assert models is atproto_client.models

--- a/tests/test_atproto_client/client/test_client.py
+++ b/tests/test_atproto_client/client/test_client.py
@@ -1,10 +1,10 @@
-import typing as t
-
+import httpx
+import pytest
+from atproto_client import Session, SessionEvent
+from atproto_client.client.async_client import AsyncClient
 from atproto_client.client.client import Client
 from atproto_client.client.methods_mixin.headers import _ATPROTO_ACCEPT_LABELERS_HEADER, _ATPROTO_PROXY_HEADER
-
-if t.TYPE_CHECKING:
-    from atproto_client import Session, SessionEvent
+from atproto_client.request import Request
 
 
 def test_client_with_bsky_chat_proxy() -> None:
@@ -73,3 +73,68 @@ def test_client_clone() -> None:
     # header sources must be the same, but different objects
     assert cloned_client.request._additional_header_sources == client.request._additional_header_sources
     assert cloned_client.request._additional_header_sources is not client.request._additional_header_sources
+
+
+def _log_in(client: Client) -> 'Session':
+    session = Session(handle='test.bsky.social', did='did:plc:test', access_jwt='access', refresh_jwt='refresh')
+    client._session_dispatcher.set_session(session)
+
+    return session
+
+
+def test_client_clone_before_login_is_authenticated() -> None:
+    client = Client()
+    cloned_client = client.clone()
+
+    assert 'Authorization' not in cloned_client.request.get_headers()
+
+    session = _log_in(client)
+
+    assert cloned_client.request.get_headers()['Authorization'] == 'Bearer access'
+    assert cloned_client._session is session
+    assert cloned_client.export_session_string() == client.export_session_string()
+
+
+def test_client_clone_before_login_shares_session_callbacks() -> None:
+    client = Client()
+    cloned_client = client.clone()
+
+    events = []
+
+    @cloned_client.on_session_change
+    def session_callback(event: 'SessionEvent', _: 'Session') -> None:
+        events.append(event)
+
+    _log_in(client)
+    client._call_on_session_change_callbacks(SessionEvent.CREATE)
+
+    assert events == [SessionEvent.CREATE]
+
+
+def test_client_clone_registers_the_auth_headers_source_once() -> None:
+    client = Client()
+    cloned_client = client.with_bsky_labeler().with_bsky_chat_proxy()
+
+    assert len(cloned_client.request._additional_header_sources) == 1
+    assert cloned_client.request._additional_header_sources == client.request._additional_header_sources
+
+
+def test_client_clone_keeps_request_config() -> None:
+    timeout = httpx.Timeout(30.0)
+
+    client = Client(request=Request(timeout=timeout))
+    cloned_client = client.with_bsky_chat_proxy()
+
+    assert cloned_client.request._client.timeout == timeout
+
+
+@pytest.mark.asyncio
+async def test_async_client_clone_before_login_is_authenticated() -> None:
+    client = AsyncClient()
+    cloned_client = client.clone()
+
+    session = Session(handle='test.bsky.social', did='did:plc:test', access_jwt='access', refresh_jwt='refresh')
+    client._session_dispatcher.set_session(session)
+
+    assert cloned_client.request.get_headers()['Authorization'] == 'Bearer access'
+    assert cloned_client._session is session

--- a/tests/test_atproto_client/client/test_request.py
+++ b/tests/test_atproto_client/client/test_request.py
@@ -1,4 +1,11 @@
-from atproto_client.request import RequestBase
+import typing as t
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+
+import httpx
+import pytest
+from atproto_client import exceptions
+from atproto_client.request import AsyncRequest, Request, RequestBase, _handle_response
 
 
 def test_get_headers_case_insensitivity() -> None:
@@ -108,3 +115,128 @@ def test_headers_from_sources() -> None:
 
     # Check that there are no duplicate headers with different cases
     assert len([k for k in headers if k.lower() == 'content-type']) == 1
+
+
+def test_clone_keeps_httpx_client_config() -> None:
+    timeout = httpx.Timeout(30.0)
+
+    request = Request(timeout=timeout)
+    cloned_request = request.clone()
+
+    assert cloned_request is not request
+    assert cloned_request._client is not request._client
+    assert cloned_request._client.timeout == timeout
+
+
+def test_async_clone_keeps_httpx_client_config() -> None:
+    timeout = httpx.Timeout(30.0)
+
+    request = AsyncRequest(timeout=timeout)
+    cloned_request = request.clone()
+
+    assert cloned_request is not request
+    assert cloned_request._client is not request._client
+    assert cloned_request._client.timeout == timeout
+
+
+def test_clone_of_clone_keeps_httpx_client_config() -> None:
+    timeout = httpx.Timeout(30.0)
+
+    request = Request(timeout=timeout).clone().clone()
+
+    assert request._client.timeout == timeout
+
+
+def _raise_for_status(status_code: int, headers: t.Optional[t.Dict[str, str]] = None) -> None:
+    _handle_response(httpx.Response(status_code, headers=headers, request=httpx.Request('GET', 'https://bsky.social')))
+
+
+def test_rate_limit_exceeded_error() -> None:
+    with pytest.raises(exceptions.RateLimitExceededError):
+        _raise_for_status(429)
+
+
+def test_rate_limit_exceeded_error_is_a_request_exception() -> None:
+    with pytest.raises(exceptions.RequestException):
+        _raise_for_status(429)
+
+
+def test_rate_limit_exceeded_error_budget() -> None:
+    headers = {
+        'ratelimit-limit': '3000',
+        'ratelimit-remaining': '0',
+        'ratelimit-reset': '1735689600',
+        'ratelimit-policy': '3000;w=300',
+    }
+
+    with pytest.raises(exceptions.RateLimitExceededError) as exc_info:
+        _raise_for_status(429, headers)
+
+    error = exc_info.value
+    assert error.limit == 3000
+    assert error.remaining == 0
+    assert error.reset_at == datetime(2025, 1, 1, tzinfo=timezone.utc)
+    assert error.policy == '3000;w=300'
+
+
+def test_rate_limit_exceeded_error_without_budget_headers() -> None:
+    with pytest.raises(exceptions.RateLimitExceededError) as exc_info:
+        _raise_for_status(429)
+
+    error = exc_info.value
+    assert error.limit is None
+    assert error.remaining is None
+    assert error.reset_at is None
+    assert error.policy is None
+
+
+def test_rate_limit_exceeded_error_with_malformed_budget_headers() -> None:
+    with pytest.raises(exceptions.RateLimitExceededError) as exc_info:
+        _raise_for_status(429, {'ratelimit-limit': 'nope', 'ratelimit-reset': 'nope'})
+
+    assert exc_info.value.limit is None
+    assert exc_info.value.reset_at is None
+
+
+def test_rate_limit_exceeded_error_retry_after_seconds() -> None:
+    with pytest.raises(exceptions.RateLimitExceededError) as exc_info:
+        _raise_for_status(429, {'retry-after': '12'})
+
+    assert exc_info.value.retry_after == 12.0
+
+
+def test_rate_limit_exceeded_error_retry_after_http_date() -> None:
+    retry_at = datetime.now(timezone.utc) + timedelta(seconds=60)
+
+    with pytest.raises(exceptions.RateLimitExceededError) as exc_info:
+        _raise_for_status(429, {'retry-after': format_datetime(retry_at, usegmt=True)})
+
+    retry_after = exc_info.value.retry_after
+    assert retry_after is not None
+    assert 55 <= retry_after <= 60
+
+
+def test_rate_limit_exceeded_error_retry_after_in_the_past_is_not_negative() -> None:
+    retry_at = datetime.now(timezone.utc) - timedelta(seconds=60)
+
+    with pytest.raises(exceptions.RateLimitExceededError) as exc_info:
+        _raise_for_status(429, {'retry-after': format_datetime(retry_at, usegmt=True)})
+
+    assert exc_info.value.retry_after == 0.0
+
+
+@pytest.mark.parametrize('value', ['soon', '', 'nan', 'inf'])
+def test_rate_limit_exceeded_error_retry_after_is_none_when_unusable(value: str) -> None:
+    with pytest.raises(exceptions.RateLimitExceededError) as exc_info:
+        _raise_for_status(429, {'retry-after': value})
+
+    assert exc_info.value.retry_after is None
+
+
+def test_rate_limit_exceeded_error_without_response() -> None:
+    error = exceptions.RateLimitExceededError()
+
+    assert error.limit is None
+    assert error.reset_at is None
+    assert error.policy is None
+    assert error.retry_after is None

--- a/tests/test_atproto_client/client/test_session.py
+++ b/tests/test_atproto_client/client/test_session.py
@@ -1,3 +1,6 @@
+import functools
+import typing as t
+
 import pytest
 from atproto_client import Session
 from atproto_client.client.session import SessionDispatcher, SessionEvent, get_session_pds_endpoint
@@ -117,3 +120,68 @@ async def test_async_session_not_modified(dispatcher: SessionDispatcher) -> None
     await dispatcher.dispatch_session_change_async(SessionEvent.CREATE)
 
     assert dispatcher._session.handle == initial_handle  # The original session remains unchanged
+
+
+def test_register_bound_method_callback(dispatcher: SessionDispatcher) -> None:
+    class Storage:
+        def __init__(self) -> None:
+            self.saved: t.Optional[Session] = None
+
+        def on_session_change(self, _: SessionEvent, session: Session) -> None:
+            self.saved = session
+
+    storage = Storage()
+    dispatcher.on_session_change(storage.on_session_change)
+    dispatcher.dispatch_session_change(SessionEvent.CREATE)
+
+    assert storage.saved is not None
+    assert storage.saved.handle == _TEST_HANDLE
+
+
+def test_register_partial_callback(dispatcher: SessionDispatcher) -> None:
+    calls = []
+
+    def callback(tag: str, event: SessionEvent, session: Session) -> None:
+        calls.append((tag, event, session.handle))
+
+    dispatcher.on_session_change(functools.partial(callback, 'tagged'))
+    dispatcher.dispatch_session_change(SessionEvent.REFRESH)
+
+    assert calls == [('tagged', SessionEvent.REFRESH, _TEST_HANDLE)]
+
+
+def test_register_callable_object_callback(dispatcher: SessionDispatcher) -> None:
+    class Callback:
+        def __init__(self) -> None:
+            self.called = False
+
+        def __call__(self, _: SessionEvent, __: Session) -> None:
+            self.called = True
+
+    callback = Callback()
+    dispatcher.on_session_change(callback)
+    dispatcher.dispatch_session_change(SessionEvent.IMPORT)
+
+    assert callback.called
+
+
+@pytest.mark.asyncio
+async def test_register_bound_async_method_callback(dispatcher: SessionDispatcher) -> None:
+    class Storage:
+        def __init__(self) -> None:
+            self.saved: t.Optional[Session] = None
+
+        async def on_session_change(self, _: SessionEvent, session: Session) -> None:
+            self.saved = session
+
+    storage = Storage()
+    dispatcher.on_session_change(storage.on_session_change)
+    await dispatcher.dispatch_session_change_async(SessionEvent.REFRESH)
+
+    assert storage.saved is not None
+    assert storage.saved.handle == _TEST_HANDLE
+
+
+def test_register_non_callable_callback(dispatcher: SessionDispatcher) -> None:
+    with pytest.raises(TypeError):
+        dispatcher.on_session_change('not a callback')  # type: ignore[arg-type]

--- a/tests/test_atproto_jetstream/test_archive_planner.py
+++ b/tests/test_atproto_jetstream/test_archive_planner.py
@@ -2,11 +2,17 @@
 
 import typing as t
 
+import httpx
 import pytest
 from atproto_client import models
-from atproto_client.exceptions import RequestException, UnauthorizedError
+from atproto_client.exceptions import (
+    RateLimitExceededError,
+    RequestErrorBase,
+    RequestException,
+    UnauthorizedError,
+)
 from atproto_client.models.common import XrpcError
-from atproto_client.request import Response
+from atproto_client.request import Response, _handle_response
 from atproto_jetstream.archive.downloader import quota_retry_after
 from atproto_jetstream.archive.planner import PlanFilters, SnapshotPlan
 
@@ -143,25 +149,25 @@ def _error(status_code: int, headers: t.Optional[dict] = None) -> t.Any:
 
 
 def test_quota_retry_after_honours_the_header() -> None:
-    assert quota_retry_after(RequestException(_error(429, {'retry-after': '12'}))) == 12.0
+    assert quota_retry_after(RateLimitExceededError(_error(429, {'retry-after': '12'}))) == 12.0
 
 
 def test_quota_retry_after_defaults_when_the_header_is_missing() -> None:
-    delay = quota_retry_after(RequestException(_error(429)))
+    delay = quota_retry_after(RateLimitExceededError(_error(429)))
 
     assert delay is not None
     assert delay > 0
 
 
 def test_quota_retry_after_defaults_when_the_header_is_junk() -> None:
-    delay = quota_retry_after(RequestException(_error(429, {'retry-after': 'soon'})))
+    delay = quota_retry_after(RateLimitExceededError(_error(429, {'retry-after': 'soon'})))
 
     assert delay is not None
     assert delay > 0
 
 
 def test_quota_retry_after_is_capped() -> None:
-    delay = quota_retry_after(RequestException(_error(429, {'retry-after': '999999'})))
+    delay = quota_retry_after(RateLimitExceededError(_error(429, {'retry-after': '999999'})))
 
     assert delay is not None
     assert delay <= 300.0
@@ -174,6 +180,20 @@ def test_quota_retry_after_ignores_other_failures() -> None:
     assert quota_retry_after(ValueError('unrelated')) is None
 
 
-@pytest.mark.parametrize('status_code', [200, 400, 401, 403, 404, 500, 503])
+def _raised_by_the_client(status_code: int, headers: t.Optional[dict] = None) -> BaseException:
+    """The exception the client actually raises for a status code."""
+    response = httpx.Response(status_code, headers=headers, request=httpx.Request('GET', 'https://example.com'))
+    with pytest.raises(RequestErrorBase) as exc_info:
+        _handle_response(response)
+
+    return exc_info.value
+
+
+@pytest.mark.parametrize('status_code', [400, 401, 403, 404, 500, 503])
 def test_only_429_is_a_quota_rejection(status_code: int) -> None:
-    assert quota_retry_after(RequestException(_error(status_code))) is None
+    assert quota_retry_after(_raised_by_the_client(status_code)) is None
+
+
+def test_a_429_from_the_client_is_a_quota_rejection() -> None:
+    # pins the wiring: the status the client maps to RateLimitExceededError is the one we back off on
+    assert quota_retry_after(_raised_by_the_client(429, {'retry-after': '12'})) == 12.0


### PR DESCRIPTION
429 now raises a dedicated exception

```python
except RateLimitExceededError as e:
    e.limit, e.remaining, e.reset_at, e.policy  # the ratelimit-* headers
    e.retry_after. # retry-after, in seconds
```