### PR TITLE
Update lexicons: add app.bsky.graph.referencelistoptout (2 changed)

### DIFF
--- a/docs/source/aliases_db.py
+++ b/docs/source/aliases_db.py
@@ -91,6 +91,7 @@ ALIASES_DB = {
     'models.AppBskyGraphMuteActor': 'atproto_client.models.app.bsky.graph.mute_actor',
     'models.AppBskyGraphMuteActorList': 'atproto_client.models.app.bsky.graph.mute_actor_list',
     'models.AppBskyGraphMuteThread': 'atproto_client.models.app.bsky.graph.mute_thread',
+    'models.AppBskyGraphReferencelistoptout': 'atproto_client.models.app.bsky.graph.referencelistoptout',
     'models.AppBskyGraphSearchStarterPacks': 'atproto_client.models.app.bsky.graph.search_starter_packs',
     'models.AppBskyGraphSearchStarterPacksV2': 'atproto_client.models.app.bsky.graph.search_starter_packs_v2',
     'models.AppBskyGraphStarterpack': 'atproto_client.models.app.bsky.graph.starterpack',

--- a/docs/source/models/app/bsky/graph/index.rst
+++ b/docs/source/models/app/bsky/graph/index.rst
@@ -161,6 +161,12 @@ Follows, blocks, mutes, lists, and starter packs.
 
       Mutes a thread preventing notifications from the thread and any of its children.
 
+   .. grid-item-card:: :octicon:`note;1em;sd-mr-1` referencelistoptout
+      :link: /models/app/bsky/graph/referencelistoptout
+      :link-type: doc
+
+      Record requesting that its author be omitted from the public presentation of a reference list.
+
    .. grid-item-card:: :octicon:`search;1em;sd-mr-1` searchStarterPacks
       :link: /models/app/bsky/graph/searchStarterPacks
       :link-type: doc
@@ -232,6 +238,7 @@ Follows, blocks, mutes, lists, and starter packs.
    muteActor </models/app/bsky/graph/muteActor>
    muteActorList </models/app/bsky/graph/muteActorList>
    muteThread </models/app/bsky/graph/muteThread>
+   referencelistoptout </models/app/bsky/graph/referencelistoptout>
    searchStarterPacks </models/app/bsky/graph/searchStarterPacks>
    searchStarterPacksV2 </models/app/bsky/graph/searchStarterPacksV2>
    starterpack </models/app/bsky/graph/starterpack>

--- a/docs/source/models/app/bsky/graph/referencelistoptout.rst
+++ b/docs/source/models/app/bsky/graph/referencelistoptout.rst
@@ -1,0 +1,9 @@
+app.bsky.graph.referencelistoptout
+==================================
+
+Record requesting that its author be omitted from the public presentation of a reference list. This record is only enforced when the subject list's current purpose is app.bsky.graph.defs#referencelist. AppView indexes at most one record per actor and list pair, and ignores duplicate records.
+
+.. automodule:: atproto_client.models.app.bsky.graph.referencelistoptout
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/redirects_map.py
+++ b/docs/source/redirects_map.py
@@ -101,6 +101,7 @@ REDIRECTS = {
     'atproto/atproto_client.models.app.bsky.graph.mute_actor.html': '/models/app/bsky/graph/muteActor/',
     'atproto/atproto_client.models.app.bsky.graph.mute_actor_list.html': '/models/app/bsky/graph/muteActorList/',
     'atproto/atproto_client.models.app.bsky.graph.mute_thread.html': '/models/app/bsky/graph/muteThread/',
+    'atproto/atproto_client.models.app.bsky.graph.referencelistoptout.html': '/models/app/bsky/graph/referencelistoptout/',
     'atproto/atproto_client.models.app.bsky.graph.search_starter_packs.html': '/models/app/bsky/graph/searchStarterPacks/',
     'atproto/atproto_client.models.app.bsky.graph.search_starter_packs_v2.html': '/models/app/bsky/graph/searchStarterPacksV2/',
     'atproto/atproto_client.models.app.bsky.graph.starterpack.html': '/models/app/bsky/graph/starterpack/',

--- a/lexicons/app.bsky.authFullApp.json
+++ b/lexicons/app.bsky.authFullApp.json
@@ -133,6 +133,7 @@
             "app.bsky.graph.list",
             "app.bsky.graph.listblock",
             "app.bsky.graph.listitem",
+            "app.bsky.graph.referencelistoptout",
             "app.bsky.graph.starterpack",
             "app.bsky.notification.declaration"
           ]

--- a/lexicons/app.bsky.graph.defs.json
+++ b/lexicons/app.bsky.graph.defs.json
@@ -53,7 +53,12 @@
       "required": ["uri", "subject"],
       "properties": {
         "uri": { "type": "string", "format": "at-uri" },
-        "subject": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+        "subject": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" },
+        "subjectOptedOut": {
+          "type": "boolean",
+          "const": true,
+          "description": "Set to true when the subject has opted out of appearing in the reference list. Only set when the viewer owns the list."
+        }
       }
     },
     "starterPackView": {
@@ -132,7 +137,12 @@
       "type": "object",
       "properties": {
         "muted": { "type": "boolean" },
-        "blocked": { "type": "string", "format": "at-uri" }
+        "blocked": { "type": "string", "format": "at-uri" },
+        "referenceListOptOut": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "The authenticated viewer's app.bsky.graph.referencelistoptout record URI for this reference list. Only set for reference lists. A client can delete this record to undo the opt-out."
+        }
       }
     },
     "notFoundActor": {

--- a/lexicons/app.bsky.graph.referencelistoptout.json
+++ b/lexicons/app.bsky.graph.referencelistoptout.json
@@ -1,0 +1,23 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.referencelistoptout",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record requesting that its author be omitted from the public presentation of a reference list. This record is only enforced when the subject list's current purpose is app.bsky.graph.defs#referencelist. AppView indexes at most one record per actor and list pair, and ignores duplicate records.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subject", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "Canonical, DID-based AT URI of the app.bsky.graph.list record from which the author requests omission."
+          },
+          "createdAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/packages/atproto_client/models/__init__.py
+++ b/packages/atproto_client/models/__init__.py
@@ -102,6 +102,7 @@ if t.TYPE_CHECKING:
     from atproto_client.models.app.bsky.graph import mute_actor as AppBskyGraphMuteActor
     from atproto_client.models.app.bsky.graph import mute_actor_list as AppBskyGraphMuteActorList
     from atproto_client.models.app.bsky.graph import mute_thread as AppBskyGraphMuteThread
+    from atproto_client.models.app.bsky.graph import referencelistoptout as AppBskyGraphReferencelistoptout
     from atproto_client.models.app.bsky.graph import search_starter_packs as AppBskyGraphSearchStarterPacks
     from atproto_client.models.app.bsky.graph import search_starter_packs_v2 as AppBskyGraphSearchStarterPacksV2
     from atproto_client.models.app.bsky.graph import starterpack as AppBskyGraphStarterpack
@@ -585,6 +586,7 @@ class _Ids:
     AppBskyGraphMuteActor: str = 'app.bsky.graph.muteActor'
     AppBskyGraphMuteActorList: str = 'app.bsky.graph.muteActorList'
     AppBskyGraphMuteThread: str = 'app.bsky.graph.muteThread'
+    AppBskyGraphReferencelistoptout: str = 'app.bsky.graph.referencelistoptout'
     AppBskyGraphSearchStarterPacks: str = 'app.bsky.graph.searchStarterPacks'
     AppBskyGraphSearchStarterPacksV2: str = 'app.bsky.graph.searchStarterPacksV2'
     AppBskyGraphStarterpack: str = 'app.bsky.graph.starterpack'

--- a/packages/atproto_client/models/app/bsky/graph/defs.py
+++ b/packages/atproto_client/models/app/bsky/graph/defs.py
@@ -62,6 +62,9 @@ class ListItemView(base.ModelBase):
 
     subject: 'models.AppBskyActorDefs.ProfileView'  #: Subject.
     uri: string_formats.AtUri  #: Uri.
+    subject_opted_out: te.Annotated[t.Optional[bool], Field(frozen=True)] = (
+        None  #: Set to true when the subject has opted out of appearing in the reference list. Only set when the viewer owns the list.
+    )
 
     py_type: t.Literal['app.bsky.graph.defs#listItemView'] = Field(
         default='app.bsky.graph.defs#listItemView', alias='$type', frozen=True
@@ -135,6 +138,9 @@ class ListViewerState(base.ModelBase):
 
     blocked: t.Optional[string_formats.AtUri] = None  #: Blocked.
     muted: t.Optional[bool] = None  #: Muted.
+    reference_list_opt_out: t.Optional[string_formats.AtUri] = (
+        None  #: The authenticated viewer's app.bsky.graph.referencelistoptout record URI for this reference list. Only set for reference lists. A client can delete this record to undo the opt-out.
+    )
 
     py_type: t.Literal['app.bsky.graph.defs#listViewerState'] = Field(
         default='app.bsky.graph.defs#listViewerState', alias='$type', frozen=True

--- a/packages/atproto_client/models/app/bsky/graph/referencelistoptout.py
+++ b/packages/atproto_client/models/app/bsky/graph/referencelistoptout.py
@@ -1,0 +1,51 @@
+#######################################################################
+# THIS IS THE AUTO-GENERATED CODE. DON'T EDIT IT BY HANDS!
+# Copyright (C) 2023-2026 Ilya (Marshal) <https://github.com/MarshalX>.
+# This file is part of Python atproto SDK. Licenced under MIT.
+#######################################################################
+
+
+import typing as t
+
+from pydantic import Field
+
+from atproto_client.models import string_formats
+
+if t.TYPE_CHECKING:
+    from atproto_client import models
+from atproto_client.models import base
+
+
+class Record(base.RecordModelBase):
+    """Record model for :obj:`app.bsky.graph.referencelistoptout`."""
+
+    created_at: string_formats.DateTime  #: Created at.
+    subject: (
+        string_formats.AtUri
+    )  #: Canonical, DID-based AT URI of the app.bsky.graph.list record from which the author requests omission.
+
+    py_type: t.Literal['app.bsky.graph.referencelistoptout'] = Field(
+        default='app.bsky.graph.referencelistoptout', alias='$type', frozen=True
+    )
+
+
+class GetRecordResponse(base.SugarResponseModelBase):
+    """Get record response for :obj:`models.AppBskyGraphReferencelistoptout.Record`."""
+
+    uri: str  #: The URI of the record.
+    value: 'models.AppBskyGraphReferencelistoptout.Record'  #: The record.
+    cid: t.Optional[str] = None  #: The CID of the record.
+
+
+class ListRecordsResponse(base.SugarResponseModelBase):
+    """List records response for :obj:`models.AppBskyGraphReferencelistoptout.Record`."""
+
+    records: t.Dict[str, 'models.AppBskyGraphReferencelistoptout.Record']  #: Map of URIs to records.
+    cursor: t.Optional[str] = None  #: Next page cursor.
+
+
+class CreateRecordResponse(base.SugarResponseModelBase):
+    """Create record response for :obj:`models.AppBskyGraphReferencelistoptout.Record`."""
+
+    uri: str  #: The URI of the record.
+    cid: str  #: The CID of the record.

--- a/packages/atproto_client/models/type_conversion.py
+++ b/packages/atproto_client/models/type_conversion.py
@@ -16,6 +16,7 @@ RECORD_TYPES = {
     'app.bsky.graph.list': 'AppBskyGraphList',
     'app.bsky.graph.listblock': 'AppBskyGraphListblock',
     'app.bsky.graph.listitem': 'AppBskyGraphListitem',
+    'app.bsky.graph.referencelistoptout': 'AppBskyGraphReferencelistoptout',
     'app.bsky.graph.starterpack': 'AppBskyGraphStarterpack',
     'app.bsky.graph.verification': 'AppBskyGraphVerification',
     'app.bsky.labeler.service': 'AppBskyLabelerService',

--- a/packages/atproto_client/models/unknown_type.py
+++ b/packages/atproto_client/models/unknown_type.py
@@ -23,6 +23,7 @@ UnknownRecordType: te.TypeAlias = t.Union[
     'models.AppBskyGraphList.Record',
     'models.AppBskyGraphListblock.Record',
     'models.AppBskyGraphListitem.Record',
+    'models.AppBskyGraphReferencelistoptout.Record',
     'models.AppBskyGraphStarterpack.Record',
     'models.AppBskyGraphVerification.Record',
     'models.AppBskyLabelerService.Record',

--- a/packages/atproto_client/namespaces/async_ns.py
+++ b/packages/atproto_client/namespaces/async_ns.py
@@ -3371,6 +3371,160 @@ class AppBskyGraphListitemRecord(AsyncRecordBase):
         return get_response_model(response, bool)
 
 
+class AppBskyGraphReferencelistoptoutRecord(AsyncRecordBase):
+    async def get(
+        self, repo: str, rkey: str, cid: t.Optional[str] = None, **kwargs: t.Any
+    ) -> 'models.AppBskyGraphReferencelistoptout.GetRecordResponse':
+        """Get a record.
+
+        Args:
+            repo: The repository (DID).
+            rkey: The record key (TID).
+            cid: The CID of the record.
+            **kwargs: Arbitrary arguments to HTTP request.
+
+        Returns:
+            :obj:`models.AppBskyGraphReferencelistoptout.GetRecordResponse`: Get record response.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        params_model = models.ComAtprotoRepoGetRecord.Params(
+            collection='app.bsky.graph.referencelistoptout', repo=repo, rkey=rkey, cid=cid
+        )
+        response = await self._client.invoke_query(
+            'com.atproto.repo.getRecord', params=params_model, output_encoding='application/json', **kwargs
+        )
+        response_model = get_response_model(response, models.ComAtprotoRepoGetRecord.Response)
+        return models.AppBskyGraphReferencelistoptout.GetRecordResponse(
+            uri=response_model.uri,
+            cid=response_model.cid,
+            value=t.cast('models.AppBskyGraphReferencelistoptout.Record', response_model.value),
+        )
+
+    async def list(
+        self,
+        repo: str,
+        cursor: t.Optional[str] = None,
+        limit: t.Optional[int] = None,
+        reverse: t.Optional[bool] = None,
+        **kwargs: t.Any,
+    ) -> 'models.AppBskyGraphReferencelistoptout.ListRecordsResponse':
+        """List a range of records in a collection.
+
+        Args:
+            repo: The repository (DID).
+            cursor: The cursor.
+            limit: The limit.
+            reverse: Whether to reverse the order.
+            **kwargs: Arbitrary arguments to HTTP request.
+
+        Returns:
+            :obj:`models.AppBskyGraphReferencelistoptout.ListRecordsResponse`: List records response.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        params_model = models.ComAtprotoRepoListRecords.Params(
+            collection='app.bsky.graph.referencelistoptout',
+            repo=repo,
+            cursor=cursor,
+            limit=limit,
+            reverse=reverse,
+        )
+        response = await self._client.invoke_query(
+            'com.atproto.repo.listRecords', params=params_model, output_encoding='application/json', **kwargs
+        )
+        response_model = get_response_model(response, models.ComAtprotoRepoListRecords.Response)
+        return models.AppBskyGraphReferencelistoptout.ListRecordsResponse(
+            records={
+                record.uri: t.cast('models.AppBskyGraphReferencelistoptout.Record', record.value)
+                for record in response_model.records
+            },
+            cursor=response_model.cursor,
+        )
+
+    async def create(
+        self,
+        repo: str,
+        record: 'models.AppBskyGraphReferencelistoptout.Record',
+        rkey: t.Optional[str] = None,
+        swap_commit: t.Optional[str] = None,
+        validate: t.Optional[bool] = True,
+        **kwargs: t.Any,
+    ) -> 'models.AppBskyGraphReferencelistoptout.CreateRecordResponse':
+        """Create a new record.
+
+        Args:
+            repo: The repository (DID).
+            record: The record.
+            rkey: The record key (TID).
+            swap_commit: The swap commit.
+            validate: Whether to validate the record.
+            **kwargs: Arbitrary arguments to HTTP request.
+
+        Returns:
+            :obj:`models.AppBskyGraphReferencelistoptout.CreateRecordResponse`: Create record response.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        data_model = models.ComAtprotoRepoCreateRecord.Data(
+            collection='app.bsky.graph.referencelistoptout',
+            repo=repo,
+            record=record,
+            rkey=rkey,
+            swap_commit=swap_commit,
+            validate_=validate,
+        )
+        response = await self._client.invoke_procedure(
+            'com.atproto.repo.createRecord',
+            data=data_model,
+            input_encoding='application/json',
+            output_encoding='application/json',
+            **kwargs,
+        )
+        response_model = get_response_model(response, models.ComAtprotoRepoCreateRecord.Response)
+        return models.AppBskyGraphReferencelistoptout.CreateRecordResponse(
+            uri=response_model.uri, cid=response_model.cid
+        )
+
+    async def delete(
+        self,
+        repo: str,
+        rkey: str,
+        swap_commit: t.Optional[str] = None,
+        swap_record: t.Optional[str] = None,
+        **kwargs: t.Any,
+    ) -> bool:
+        """Delete a record, or ensure it doesn't exist.
+
+        Args:
+            repo: The repository (DID).
+            rkey: The record key (TID).
+            swap_commit: The swap commit.
+            swap_record: The swap record.
+            **kwargs: Arbitrary arguments to HTTP request.
+
+        Returns:
+            :obj:`bool`: Success status.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        data_model = models.ComAtprotoRepoDeleteRecord.Data(
+            collection='app.bsky.graph.referencelistoptout',
+            repo=repo,
+            rkey=rkey,
+            swap_commit=swap_commit,
+            swap_record=swap_record,
+        )
+        response = await self._client.invoke_procedure(
+            'com.atproto.repo.deleteRecord', data=data_model, input_encoding='application/json', **kwargs
+        )
+        return get_response_model(response, bool)
+
+
 class AppBskyGraphStarterpackRecord(AsyncRecordBase):
     async def get(
         self, repo: str, rkey: str, cid: t.Optional[str] = None, **kwargs: t.Any
@@ -3683,6 +3837,7 @@ class AppBskyGraphNamespace(AsyncNamespaceBase):
         self.list = AppBskyGraphListRecord(self._client)
         self.listblock = AppBskyGraphListblockRecord(self._client)
         self.listitem = AppBskyGraphListitemRecord(self._client)
+        self.referencelistoptout = AppBskyGraphReferencelistoptoutRecord(self._client)
         self.starterpack = AppBskyGraphStarterpackRecord(self._client)
         self.verification = AppBskyGraphVerificationRecord(self._client)
 

--- a/packages/atproto_client/namespaces/sync_ns.py
+++ b/packages/atproto_client/namespaces/sync_ns.py
@@ -3371,6 +3371,160 @@ class AppBskyGraphListitemRecord(RecordBase):
         return get_response_model(response, bool)
 
 
+class AppBskyGraphReferencelistoptoutRecord(RecordBase):
+    def get(
+        self, repo: str, rkey: str, cid: t.Optional[str] = None, **kwargs: t.Any
+    ) -> 'models.AppBskyGraphReferencelistoptout.GetRecordResponse':
+        """Get a record.
+
+        Args:
+            repo: The repository (DID).
+            rkey: The record key (TID).
+            cid: The CID of the record.
+            **kwargs: Arbitrary arguments to HTTP request.
+
+        Returns:
+            :obj:`models.AppBskyGraphReferencelistoptout.GetRecordResponse`: Get record response.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        params_model = models.ComAtprotoRepoGetRecord.Params(
+            collection='app.bsky.graph.referencelistoptout', repo=repo, rkey=rkey, cid=cid
+        )
+        response = self._client.invoke_query(
+            'com.atproto.repo.getRecord', params=params_model, output_encoding='application/json', **kwargs
+        )
+        response_model = get_response_model(response, models.ComAtprotoRepoGetRecord.Response)
+        return models.AppBskyGraphReferencelistoptout.GetRecordResponse(
+            uri=response_model.uri,
+            cid=response_model.cid,
+            value=t.cast('models.AppBskyGraphReferencelistoptout.Record', response_model.value),
+        )
+
+    def list(
+        self,
+        repo: str,
+        cursor: t.Optional[str] = None,
+        limit: t.Optional[int] = None,
+        reverse: t.Optional[bool] = None,
+        **kwargs: t.Any,
+    ) -> 'models.AppBskyGraphReferencelistoptout.ListRecordsResponse':
+        """List a range of records in a collection.
+
+        Args:
+            repo: The repository (DID).
+            cursor: The cursor.
+            limit: The limit.
+            reverse: Whether to reverse the order.
+            **kwargs: Arbitrary arguments to HTTP request.
+
+        Returns:
+            :obj:`models.AppBskyGraphReferencelistoptout.ListRecordsResponse`: List records response.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        params_model = models.ComAtprotoRepoListRecords.Params(
+            collection='app.bsky.graph.referencelistoptout',
+            repo=repo,
+            cursor=cursor,
+            limit=limit,
+            reverse=reverse,
+        )
+        response = self._client.invoke_query(
+            'com.atproto.repo.listRecords', params=params_model, output_encoding='application/json', **kwargs
+        )
+        response_model = get_response_model(response, models.ComAtprotoRepoListRecords.Response)
+        return models.AppBskyGraphReferencelistoptout.ListRecordsResponse(
+            records={
+                record.uri: t.cast('models.AppBskyGraphReferencelistoptout.Record', record.value)
+                for record in response_model.records
+            },
+            cursor=response_model.cursor,
+        )
+
+    def create(
+        self,
+        repo: str,
+        record: 'models.AppBskyGraphReferencelistoptout.Record',
+        rkey: t.Optional[str] = None,
+        swap_commit: t.Optional[str] = None,
+        validate: t.Optional[bool] = True,
+        **kwargs: t.Any,
+    ) -> 'models.AppBskyGraphReferencelistoptout.CreateRecordResponse':
+        """Create a new record.
+
+        Args:
+            repo: The repository (DID).
+            record: The record.
+            rkey: The record key (TID).
+            swap_commit: The swap commit.
+            validate: Whether to validate the record.
+            **kwargs: Arbitrary arguments to HTTP request.
+
+        Returns:
+            :obj:`models.AppBskyGraphReferencelistoptout.CreateRecordResponse`: Create record response.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        data_model = models.ComAtprotoRepoCreateRecord.Data(
+            collection='app.bsky.graph.referencelistoptout',
+            repo=repo,
+            record=record,
+            rkey=rkey,
+            swap_commit=swap_commit,
+            validate_=validate,
+        )
+        response = self._client.invoke_procedure(
+            'com.atproto.repo.createRecord',
+            data=data_model,
+            input_encoding='application/json',
+            output_encoding='application/json',
+            **kwargs,
+        )
+        response_model = get_response_model(response, models.ComAtprotoRepoCreateRecord.Response)
+        return models.AppBskyGraphReferencelistoptout.CreateRecordResponse(
+            uri=response_model.uri, cid=response_model.cid
+        )
+
+    def delete(
+        self,
+        repo: str,
+        rkey: str,
+        swap_commit: t.Optional[str] = None,
+        swap_record: t.Optional[str] = None,
+        **kwargs: t.Any,
+    ) -> bool:
+        """Delete a record, or ensure it doesn't exist.
+
+        Args:
+            repo: The repository (DID).
+            rkey: The record key (TID).
+            swap_commit: The swap commit.
+            swap_record: The swap record.
+            **kwargs: Arbitrary arguments to HTTP request.
+
+        Returns:
+            :obj:`bool`: Success status.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        data_model = models.ComAtprotoRepoDeleteRecord.Data(
+            collection='app.bsky.graph.referencelistoptout',
+            repo=repo,
+            rkey=rkey,
+            swap_commit=swap_commit,
+            swap_record=swap_record,
+        )
+        response = self._client.invoke_procedure(
+            'com.atproto.repo.deleteRecord', data=data_model, input_encoding='application/json', **kwargs
+        )
+        return get_response_model(response, bool)
+
+
 class AppBskyGraphStarterpackRecord(RecordBase):
     def get(
         self, repo: str, rkey: str, cid: t.Optional[str] = None, **kwargs: t.Any
@@ -3683,6 +3837,7 @@ class AppBskyGraphNamespace(NamespaceBase):
         self.list = AppBskyGraphListRecord(self._client)
         self.listblock = AppBskyGraphListblockRecord(self._client)
         self.listitem = AppBskyGraphListitemRecord(self._client)
+        self.referencelistoptout = AppBskyGraphReferencelistoptoutRecord(self._client)
         self.starterpack = AppBskyGraphStarterpackRecord(self._client)
         self.verification = AppBskyGraphVerificationRecord(self._client)
 


### PR DESCRIPTION
Automated update of the vendored lexicons and everything generated from them.

Fetched from:

- [`bluesky-social/atproto@60c4395`](https://github.com/bluesky-social/atproto/commit/60c439595101fbcbe612463e6f23200590c5daaf) (2026-08-31T22:38:58Z)
- [`bluesky-social/jetstream@11e399d`](https://github.com/bluesky-social/jetstream/commit/11e399d402cea54df8b6696e35020a3147a52ed6) (2026-08-12T16:51:26Z)

## Lexicon changes

### New lexicons

- `app.bsky.graph.referencelistoptout`

### New fields

- `app.bsky.graph.defs#listItemView.subjectOptedOut`
- `app.bsky.graph.defs#listViewerState.referenceListOptOut`

### Updated permission sets

- `app.bsky.authFullApp`