### PR TITLE
Update lexicons: add app.bsky.actor.defs#interestsPref.updatedAt (1 changed)

### DIFF
--- a/docs/source/aliases_db.py
+++ b/docs/source/aliases_db.py
@@ -332,6 +332,7 @@ ALIASES_DB = {
     'models.ToolsOzoneModerationCancelScheduledActions': 'atproto_client.models.tools.ozone.moderation.cancel_scheduled_actions',
     'models.ToolsOzoneModerationDefs': 'atproto_client.models.tools.ozone.moderation.defs',
     'models.ToolsOzoneModerationEmitEvent': 'atproto_client.models.tools.ozone.moderation.emit_event',
+    'models.ToolsOzoneModerationGetAccountPreferences': 'atproto_client.models.tools.ozone.moderation.get_account_preferences',
     'models.ToolsOzoneModerationGetAccountTimeline': 'atproto_client.models.tools.ozone.moderation.get_account_timeline',
     'models.ToolsOzoneModerationGetEvent': 'atproto_client.models.tools.ozone.moderation.get_event',
     'models.ToolsOzoneModerationGetRecord': 'atproto_client.models.tools.ozone.moderation.get_record',

--- a/docs/source/models/tools/ozone/moderation/getAccountPreferences.rst
+++ b/docs/source/models/tools/ozone/moderation/getAccountPreferences.rst
@@ -1,0 +1,9 @@
+tools.ozone.moderation.getAccountPreferences
+============================================
+
+Get private preferences for an account. Requires moderator or admin auth.
+
+.. automodule:: atproto_client.models.tools.ozone.moderation.get_account_preferences
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/models/tools/ozone/moderation/index.rst
+++ b/docs/source/models/tools/ozone/moderation/index.rst
@@ -29,6 +29,12 @@ Moderation events, reports, and subject state.
 
       Take a moderation action on an actor.
 
+   .. grid-item-card:: :octicon:`search;1em;sd-mr-1` getAccountPreferences
+      :link: /models/tools/ozone/moderation/getAccountPreferences
+      :link-type: doc
+
+      Get private preferences for an account.
+
    .. grid-item-card:: :octicon:`search;1em;sd-mr-1` getAccountTimeline
       :link: /models/tools/ozone/moderation/getAccountTimeline
       :link-type: doc
@@ -114,6 +120,7 @@ Moderation events, reports, and subject state.
    cancelScheduledActions </models/tools/ozone/moderation/cancelScheduledActions>
    defs </models/tools/ozone/moderation/defs>
    emitEvent </models/tools/ozone/moderation/emitEvent>
+   getAccountPreferences </models/tools/ozone/moderation/getAccountPreferences>
    getAccountTimeline </models/tools/ozone/moderation/getAccountTimeline>
    getEvent </models/tools/ozone/moderation/getEvent>
    getRecord </models/tools/ozone/moderation/getRecord>

--- a/docs/source/redirects_map.py
+++ b/docs/source/redirects_map.py
@@ -391,6 +391,7 @@ REDIRECTS = {
     'atproto/atproto_client.models.tools.ozone.moderation.cancel_scheduled_actions.html': '/models/tools/ozone/moderation/cancelScheduledActions/',
     'atproto/atproto_client.models.tools.ozone.moderation.defs.html': '/models/tools/ozone/moderation/defs/',
     'atproto/atproto_client.models.tools.ozone.moderation.emit_event.html': '/models/tools/ozone/moderation/emitEvent/',
+    'atproto/atproto_client.models.tools.ozone.moderation.get_account_preferences.html': '/models/tools/ozone/moderation/getAccountPreferences/',
     'atproto/atproto_client.models.tools.ozone.moderation.get_account_timeline.html': '/models/tools/ozone/moderation/getAccountTimeline/',
     'atproto/atproto_client.models.tools.ozone.moderation.get_event.html': '/models/tools/ozone/moderation/getEvent/',
     'atproto/atproto_client.models.tools.ozone.moderation.get_record.html': '/models/tools/ozone/moderation/getRecord/',

--- a/lexicons/app.bsky.actor.defs.json
+++ b/lexicons/app.bsky.actor.defs.json
@@ -480,6 +480,11 @@
       "type": "object",
       "required": ["tags"],
       "properties": {
+        "updatedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "The timestamp when the account owner last updated their interests."
+        },
         "tags": {
           "type": "array",
           "maxLength": 100,

--- a/lexicons/tools.ozone.moderation.getAccountPreferences.json
+++ b/lexicons/tools.ozone.moderation.getAccountPreferences.json
@@ -1,0 +1,33 @@
+{
+  "lexicon": 1,
+  "id": "tools.ozone.moderation.getAccountPreferences",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get private preferences for an account. Requires moderator or admin auth.",
+      "parameters": {
+        "type": "params",
+        "required": ["did"],
+        "properties": {
+          "did": {
+            "type": "string",
+            "format": "did"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["preferences"],
+          "properties": {
+            "preferences": {
+              "type": "ref",
+              "ref": "app.bsky.actor.defs#preferences"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/atproto_client/models/__init__.py
+++ b/packages/atproto_client/models/__init__.py
@@ -404,6 +404,9 @@ if t.TYPE_CHECKING:
     from atproto_client.models.tools.ozone.moderation import defs as ToolsOzoneModerationDefs
     from atproto_client.models.tools.ozone.moderation import emit_event as ToolsOzoneModerationEmitEvent
     from atproto_client.models.tools.ozone.moderation import (
+        get_account_preferences as ToolsOzoneModerationGetAccountPreferences,
+    )
+    from atproto_client.models.tools.ozone.moderation import (
         get_account_timeline as ToolsOzoneModerationGetAccountTimeline,
     )
     from atproto_client.models.tools.ozone.moderation import get_event as ToolsOzoneModerationGetEvent
@@ -831,6 +834,7 @@ class _Ids:
     ToolsOzoneModerationCancelScheduledActions: str = 'tools.ozone.moderation.cancelScheduledActions'
     ToolsOzoneModerationDefs: str = 'tools.ozone.moderation.defs'
     ToolsOzoneModerationEmitEvent: str = 'tools.ozone.moderation.emitEvent'
+    ToolsOzoneModerationGetAccountPreferences: str = 'tools.ozone.moderation.getAccountPreferences'
     ToolsOzoneModerationGetAccountTimeline: str = 'tools.ozone.moderation.getAccountTimeline'
     ToolsOzoneModerationGetEvent: str = 'tools.ozone.moderation.getEvent'
     ToolsOzoneModerationGetRecord: str = 'tools.ozone.moderation.getRecord'

--- a/packages/atproto_client/models/app/bsky/actor/defs.py
+++ b/packages/atproto_client/models/app/bsky/actor/defs.py
@@ -356,6 +356,9 @@ class InterestsPref(base.ModelBase):
     tags: t.List[te.Annotated[str, Field(max_length=640)]] = Field(
         max_length=100
     )  #: A list of tags which describe the account owner's interests gathered during onboarding.
+    updated_at: t.Optional[string_formats.DateTime] = (
+        None  #: The timestamp when the account owner last updated their interests.
+    )
 
     py_type: t.Literal['app.bsky.actor.defs#interestsPref'] = Field(
         default='app.bsky.actor.defs#interestsPref', alias='$type', frozen=True

--- a/packages/atproto_client/models/tools/ozone/moderation/get_account_preferences.py
+++ b/packages/atproto_client/models/tools/ozone/moderation/get_account_preferences.py
@@ -1,0 +1,30 @@
+#######################################################################
+# THIS IS THE AUTO-GENERATED CODE. DON'T EDIT IT BY HANDS!
+# Copyright (C) 2023-2026 Ilya (Marshal) <https://github.com/MarshalX>.
+# This file is part of Python atproto SDK. Licenced under MIT.
+#######################################################################
+
+
+import typing as t
+
+from atproto_client.models import string_formats
+
+if t.TYPE_CHECKING:
+    from atproto_client import models
+from atproto_client.models import base
+
+
+class Params(base.ParamsModelBase):
+    """Parameters model for :obj:`tools.ozone.moderation.getAccountPreferences`."""
+
+    did: string_formats.Did  #: Did.
+
+
+class ParamsDict(t.TypedDict):
+    did: string_formats.Did  #: Did.
+
+
+class Response(base.ResponseModelBase):
+    """Output data model for :obj:`tools.ozone.moderation.getAccountPreferences`."""
+
+    preferences: 'models.AppBskyActorDefs.Preferences'  #: Preferences.

--- a/packages/atproto_client/namespaces/async_ns.py
+++ b/packages/atproto_client/namespaces/async_ns.py
@@ -11549,6 +11549,38 @@ class ToolsOzoneModerationNamespace(AsyncNamespaceBase):
         )
         return get_response_model(response, models.ToolsOzoneModerationDefs.ModEventView)
 
+    async def get_account_preferences(
+        self,
+        params: t.Union[
+            models.ToolsOzoneModerationGetAccountPreferences.Params,
+            models.ToolsOzoneModerationGetAccountPreferences.ParamsDict,
+        ],
+        **kwargs: t.Any,
+    ) -> 'models.ToolsOzoneModerationGetAccountPreferences.Response':
+        """Get private preferences for an account. Requires moderator or admin auth.
+
+        Args:
+            params: Parameters.
+            **kwargs: Arbitrary arguments to HTTP request.
+
+        Returns:
+            :obj:`models.ToolsOzoneModerationGetAccountPreferences.Response`: Output model.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        params_model = t.cast(
+            'models.ToolsOzoneModerationGetAccountPreferences.Params',
+            get_or_create(params, models.ToolsOzoneModerationGetAccountPreferences.Params),
+        )
+        response = await self._client.invoke_query(
+            'tools.ozone.moderation.getAccountPreferences',
+            params=params_model,
+            output_encoding='application/json',
+            **kwargs,
+        )
+        return get_response_model(response, models.ToolsOzoneModerationGetAccountPreferences.Response)
+
     async def get_account_timeline(
         self,
         params: t.Union[

--- a/packages/atproto_client/namespaces/sync_ns.py
+++ b/packages/atproto_client/namespaces/sync_ns.py
@@ -11547,6 +11547,38 @@ class ToolsOzoneModerationNamespace(NamespaceBase):
         )
         return get_response_model(response, models.ToolsOzoneModerationDefs.ModEventView)
 
+    def get_account_preferences(
+        self,
+        params: t.Union[
+            models.ToolsOzoneModerationGetAccountPreferences.Params,
+            models.ToolsOzoneModerationGetAccountPreferences.ParamsDict,
+        ],
+        **kwargs: t.Any,
+    ) -> 'models.ToolsOzoneModerationGetAccountPreferences.Response':
+        """Get private preferences for an account. Requires moderator or admin auth.
+
+        Args:
+            params: Parameters.
+            **kwargs: Arbitrary arguments to HTTP request.
+
+        Returns:
+            :obj:`models.ToolsOzoneModerationGetAccountPreferences.Response`: Output model.
+
+        Raises:
+            :class:`atproto.exceptions.AtProtocolError`: Base exception.
+        """
+        params_model = t.cast(
+            'models.ToolsOzoneModerationGetAccountPreferences.Params',
+            get_or_create(params, models.ToolsOzoneModerationGetAccountPreferences.Params),
+        )
+        response = self._client.invoke_query(
+            'tools.ozone.moderation.getAccountPreferences',
+            params=params_model,
+            output_encoding='application/json',
+            **kwargs,
+        )
+        return get_response_model(response, models.ToolsOzoneModerationGetAccountPreferences.Response)
+
     def get_account_timeline(
         self,
         params: t.Union[


### PR DESCRIPTION
Automated update of the vendored lexicons and everything generated from them.

Fetched from:

- [`bluesky-social/atproto@f0d4877`](https://github.com/bluesky-social/atproto/commit/f0d4877a03dc8ede0d3e9a36d5b72ada63b5d2e0) (2026-09-03T18:02:59Z)
- [`bluesky-social/jetstream@11e399d`](https://github.com/bluesky-social/jetstream/commit/11e399d402cea54df8b6696e35020a3147a52ed6) (2026-08-12T16:51:26Z)

## Lexicon changes

### New fields

- `app.bsky.actor.defs#interestsPref.updatedAt`

<details>
<summary>Changes in tools.ozone and internal namespaces</summary>

### New lexicons

- `tools.ozone.moderation.getAccountPreferences`

</details>